### PR TITLE
Add migration generators for all 19 Rodauth features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Rodauth::Rack provides core Rodauth authentication functionality for any Rack fr
 
 - **Framework Agnostic**: Works with any Rack 3 framework
 - **Adapter Interface**: Clean separation between Rodauth core and framework-specific concerns
+- **Migration Generators**: 19 database migration templates for both ActiveRecord and Sequel
 - **Flexible Middleware**: Easy integration into existing applications
 - **Well Tested**: Comprehensive test suite with >80% coverage
 - **Production Ready**: Battle-tested patterns extracted from rodauth-rails
@@ -20,28 +21,28 @@ Rodauth::Rack provides core Rodauth authentication functionality for any Rack fr
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                  Your Application                    │
+│                  Your Application                   │
 │              (Rails, Hanami, Sinatra, etc.)         │
 └──────────────────┬──────────────────────────────────┘
                    │
                    ▼
 ┌─────────────────────────────────────────────────────┐
-│           Framework-Specific Adapter                 │
+│           Framework-Specific Adapter                │
 │    (rodauth-rack-rails, rodauth-rack-hanami, etc.)  │
 └──────────────────┬──────────────────────────────────┘
                    │
                    ▼
 ┌─────────────────────────────────────────────────────┐
-│              Rodauth::Rack (Core)                    │
+│              Rodauth::Rack (Core)                   │
 │  • Adapter::Base (interface)                        │
-│  • Middleware (request routing)                      │
-│  • Configuration                                     │
+│  • Middleware (request routing)                     │
+│  • Configuration                                    │
 └──────────────────┬──────────────────────────────────┘
                    │
                    ▼
 ┌─────────────────────────────────────────────────────┐
-│                   Rodauth                            │
-│              (Authentication Logic)                  │
+│                   Rodauth                           │
+│              (Authentication Logic)                 │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -79,6 +80,57 @@ bundle install
 - Sinatra/Roda: Use the CLI tool `rodauth-cli` (coming soon)
 
 ## Usage
+
+### Migration Generators
+
+Generate database migrations for Rodauth features:
+
+```ruby
+# For Sequel
+generator = Rodauth::Rack::Generators::Migration.new(
+  features: [:base, :verify_account, :otp],
+  orm: :sequel,
+  prefix: "account"
+)
+
+puts generator.generate  # migration content
+puts generator.configuration  # Rodauth config
+
+# For ActiveRecord
+generator = Rodauth::Rack::Generators::Migration.new(
+  features: [:base, :reset_password],
+  orm: :active_record,
+  prefix: "user",
+  db_adapter: :postgresql
+)
+
+File.write("db/migrate/#{Time.now.utc.strftime('%Y%m%d%H%M%S')}_create_rodauth.rb",
+           generator.generate)
+```
+
+#### Available Features
+
+The generator supports all 19 Rodauth database features:
+
+- `base` - Core accounts table
+- `remember` - Remember me functionality
+- `verify_account` - Account verification
+- `verify_login_change` - Login change verification
+- `reset_password` - Password reset
+- `email_auth` - Passwordless email authentication
+- `otp` - TOTP multifactor authentication
+- `otp_unlock` - OTP unlock
+- `sms_codes` - SMS codes
+- `recovery_codes` - Backup recovery codes
+- `webauthn` - WebAuthn keys
+- `lockout` - Account lockouts
+- `active_sessions` - Session management
+- `account_expiration` - Account expiration
+- `password_expiration` - Password expiration
+- `single_session` - Single session per account
+- `audit_logging` - Authentication audit logs
+- `disallow_password_reuse` - Password history
+- `jwt_refresh` - JWT refresh tokens
 
 ### For Framework Developers
 
@@ -133,13 +185,28 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/delano/rodauth-rack. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/delano/rodauth-rack/blob/main/CODE_OF_CONDUCT.md).
 
+## AI Development Assistance
+
+This project was developed with assistance from AI tools for initial planning and implementation:
+
+- **Claude (Desktop, Code Max plan, Sonnet 4.5)** - Created issue tickets, project scaffolding, gem structure, migration generators, and documentation
+
+I remain responsible for all design decisions and code. I believe in being transparent about development tools, especially as AI becomes more integrated into our workflows as developers. -- delano
+
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Acknowledgments
 
-This gem extracts and builds upon patterns from [rodauth-rails](https://github.com/janko/rodauth-rails) by Janko Marohnić, released under the MIT License. We're grateful for the excellent foundation provided by that project.
+This gem extracts and builds upon patterns from [rodauth-rails](https://github.com/janko/rodauth-rails) by Janko Marohnić, released under the MIT License. Specifically:
+
+- **Migration Templates**: All 19 database migration templates (ActiveRecord and Sequel) are copied directly from rodauth-rails with minimal modifications for framework independence
+- **Generator Patterns**: The migration generator architecture follows rodauth-rails' proven design
+- **Configuration**: Feature configuration mapping extracted from rodauth-rails
+
+We're grateful for the excellent foundation provided by the rodauth-rails project.
 
 ## Code of Conduct
 

--- a/lib/rodauth/rack.rb
+++ b/lib/rodauth/rack.rb
@@ -3,6 +3,7 @@
 require_relative "rack/version"
 require_relative "rack/adapter/base"
 require_relative "rack/middleware"
+require_relative "rack/generators/migration"
 
 module Rodauth
   module Rack

--- a/lib/rodauth/rack/generators/migration.rb
+++ b/lib/rodauth/rack/generators/migration.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module Rodauth
+  module Rack
+    module Generators
+      # Framework-agnostic migration generator for Rodauth database tables.
+      #
+      # Generates migrations for both ActiveRecord and Sequel ORMs, supporting
+      # PostgreSQL, MySQL, and SQLite3 databases.
+      #
+      # @example Generate a migration
+      #   generator = Rodauth::Rack::Generators::Migration.new(
+      #     features: [:base, :verify_account, :otp],
+      #     orm: :sequel,
+      #     prefix: "account",
+      #     db_adapter: :postgresql
+      #   )
+      #
+      #   generator.generate # => migration content
+      #   generator.configuration # => Rodauth config hash
+      class Migration
+        attr_reader :features, :orm, :prefix, :db_adapter, :db
+
+        # Feature configuration mapping for Rodauth
+        #
+        # Maps feature names to their required table configurations
+        CONFIGURATION = {
+          base: { accounts_table: "%{plural}" },
+          remember: { remember_table: "%{singular}_remember_keys" },
+          verify_account: { verify_account_table: "%{singular}_verification_keys" },
+          verify_login_change: { verify_login_change_table: "%{singular}_login_change_keys" },
+          reset_password: { reset_password_table: "%{singular}_password_reset_keys" },
+          email_auth: { email_auth_table: "%{singular}_email_auth_keys" },
+          otp: { otp_keys_table: "%{singular}_otp_keys" },
+          otp_unlock: { otp_unlock_table: "%{singular}_otp_unlocks" },
+          sms_codes: { sms_codes_table: "%{singular}_sms_codes" },
+          recovery_codes: { recovery_codes_table: "%{singular}_recovery_codes" },
+          webauthn: {
+            webauthn_keys_table: "%{singular}_webauthn_keys",
+            webauthn_user_ids_table: "%{singular}_webauthn_user_ids",
+            webauthn_keys_account_id_column: "%{singular}_id"
+          },
+          lockout: {
+            account_login_failures_table: "%{singular}_login_failures",
+            account_lockouts_table: "%{singular}_lockouts"
+          },
+          active_sessions: {
+            active_sessions_table: "%{singular}_active_session_keys",
+            active_sessions_account_id_column: "%{singular}_id"
+          },
+          account_expiration: { account_activity_table: "%{singular}_activity_times" },
+          password_expiration: { password_expiration_table: "%{singular}_password_change_times" },
+          single_session: { single_session_table: "%{singular}_session_keys" },
+          audit_logging: {
+            audit_logging_table: "%{singular}_authentication_audit_logs",
+            audit_logging_account_id_column: "%{singular}_id"
+          },
+          disallow_password_reuse: {
+            previous_password_hash_table: "%{singular}_previous_password_hashes",
+            previous_password_account_id_column: "%{singular}_id"
+          },
+          jwt_refresh: {
+            jwt_refresh_token_table: "%{singular}_jwt_refresh_keys",
+            jwt_refresh_token_account_id_column: "%{singular}_id"
+          }
+        }.freeze
+
+        # Initialize the migration generator
+        #
+        # @param features [Array<Symbol>] List of Rodauth features to generate tables for
+        # @param orm [Symbol] ORM to use (:active_record or :sequel)
+        # @param prefix [String] Table name prefix (default: "account")
+        # @param db_adapter [Symbol] Database adapter (:postgresql, :mysql2, :sqlite3)
+        # @param db [Sequel::Database] Sequel database connection (for Sequel ORM only)
+        def initialize(features:, orm: :sequel, prefix: nil, db_adapter: nil, db: nil)
+          @features = Array(features).map(&:to_sym)
+          @orm = orm.to_sym
+          @prefix = prefix
+          @db_adapter = db_adapter&.to_sym
+          @db = db || (orm == :sequel ? create_mock_db : nil)
+
+          validate_features!
+          validate_orm!
+          validate_feature_templates!
+        end
+
+        # Generate the migration content
+        #
+        # @return [String] Complete migration file content
+        def generate
+          features
+            .map { |feature| load_template(feature) }
+            .map { |content| evaluate_erb(content) }
+            .join("\n")
+        end
+
+        # Get the Rodauth configuration for the selected features
+        #
+        # @return [Hash] Configuration hash with table names
+        def configuration
+          CONFIGURATION.values_at(*features)
+            .compact
+            .reduce({}, :merge)
+            .transform_values { |format| format % { plural: table_prefix.pluralize, singular: table_prefix } }
+        end
+
+        # Get the migration name
+        #
+        # @return [String] Migration name
+        def migration_name
+          parts = ["create_rodauth"]
+          parts << prefix if prefix && prefix != "account"
+          parts.concat(features)
+          parts.join("_")
+        end
+
+        private
+
+        def validate_features!
+          return if features.any?
+
+          raise ArgumentError, "No features specified"
+        end
+
+        def validate_feature_templates!
+          features.each do |feature|
+            template_path = File.join(template_directory, "#{feature}.erb")
+            unless File.exist?(template_path)
+              raise ArgumentError, "No migration template for feature: #{feature}"
+            end
+          end
+        end
+
+        def validate_orm!
+          unless %i[active_record sequel].include?(orm)
+            raise ArgumentError, "Invalid ORM: #{orm}. Must be :active_record or :sequel"
+          end
+        end
+
+        def create_mock_db
+          adapter = @db_adapter || :postgres
+          MockSequelDatabase.new(adapter)
+        end
+
+        def load_template(feature)
+          template_path = File.join(template_directory, "#{feature}.erb")
+          File.read(template_path)
+        end
+
+        def evaluate_erb(content)
+          ERB.new(content, trim_mode: "-").result(binding)
+        end
+
+        def template_directory
+          File.join(__dir__, "migration", orm.to_s)
+        end
+
+        def table_prefix
+          (@prefix || "account").to_s
+        end
+
+        # Methods for ERB templates
+
+        def activerecord_adapter
+          @db_adapter&.to_s || "postgresql"
+        end
+
+        def primary_key_type(key = :id)
+          column_type = default_primary_key_type
+
+          if key
+            ", #{key}: :#{column_type}"
+          else
+            column_type
+          end
+        end
+
+        def default_primary_key_type
+          activerecord_adapter == "sqlite3" ? :integer : :bigint
+        end
+
+        def current_timestamp
+          if activerecord_adapter =~ /mysql/ && supports_datetime_with_precision?
+            "CURRENT_TIMESTAMP(6)"
+          else
+            "CURRENT_TIMESTAMP"
+          end
+        end
+
+        def supports_datetime_with_precision?
+          # This is a simplified version - actual implementation would check database version
+          true
+        end
+
+        # Mock database object for Sequel templates when no real db is provided
+        class MockSequelDatabase
+          attr_reader :database_type
+
+          def initialize(adapter = :postgres)
+            @database_type = adapter
+          end
+
+          def supports_partial_indexes?
+            database_type == :postgres || database_type == :sqlite
+          end
+        end
+      end
+    end
+  end
+end
+
+# String extensions for singularize/pluralize
+# Simplified implementation - in production, use ActiveSupport or similar
+class String
+  unless method_defined?(:pluralize)
+    def pluralize
+      return self if self.end_with?("s")
+      self + "s"
+    end
+  end
+
+  unless method_defined?(:singularize)
+    def singularize
+      return self unless self.end_with?("s")
+      self[0..-2]
+    end
+  end
+end

--- a/lib/rodauth/rack/generators/migration/active_record/account_expiration.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/account_expiration.erb
@@ -1,0 +1,8 @@
+# Used by the account expiration feature
+create_table :<%= table_prefix %>_activity_times, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.datetime :last_activity_at, null: false
+  t.datetime :last_login_at, null: false
+  t.datetime :expired_at
+end

--- a/lib/rodauth/rack/generators/migration/active_record/active_sessions.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/active_sessions.erb
@@ -1,0 +1,7 @@
+# Used by the active sessions feature
+create_table :<%= table_prefix %>_active_session_keys, primary_key: [:<%= table_prefix %>_id, :session_id] do |t|
+  t.references :<%= table_prefix %>, foreign_key: true<%= primary_key_type(:type) %>
+  t.string :session_id
+  t.datetime :created_at, null: false, default: -> { "<%= current_timestamp %>" }
+  t.datetime :last_use, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/audit_logging.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/audit_logging.erb
@@ -1,0 +1,16 @@
+# Used by the audit logging feature
+create_table :<%= table_prefix %>_authentication_audit_logs<%= primary_key_type %> do |t|
+  t.references :<%= table_prefix %>, foreign_key: true, null: false<%= primary_key_type(:type) %>
+  t.datetime :at, null: false, default: -> { "<%= current_timestamp %>" }
+  t.text :message, null: false
+<% case activerecord_adapter -%>
+<% when "postgresql" -%>
+  t.jsonb :metadata
+<% when "sqlite3", "mysql2", "trilogy" -%>
+  t.json :metadata
+<% else -%>
+  t.string :metadata
+<% end -%>
+  t.index [:<%= table_prefix %>_id, :at]
+  t.index :at
+end

--- a/lib/rodauth/rack/generators/migration/active_record/base.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/base.erb
@@ -1,0 +1,21 @@
+<% if activerecord_adapter == "postgresql" -%>
+enable_extension "citext"
+
+<% end -%>
+create_table :<%= table_prefix.pluralize %><%= primary_key_type %> do |t|
+  t.integer :status, null: false, default: 1
+<% case activerecord_adapter -%>
+<% when "postgresql" -%>
+  t.citext :email, null: false
+  t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$'", name: "valid_email"
+<% else -%>
+  t.string :email, null: false
+<% end -%>
+<% case activerecord_adapter -%>
+<% when "postgresql", "sqlite3" -%>
+  t.index :email, unique: true, where: "status IN (1, 2)"
+<% else -%>
+  t.index :email, unique: true
+<% end -%>
+  t.string :password_hash
+end

--- a/lib/rodauth/rack/generators/migration/active_record/disallow_password_reuse.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/disallow_password_reuse.erb
@@ -1,0 +1,5 @@
+# Used by the disallow password reuse feature
+create_table :<%= table_prefix %>_previous_password_hashes do |t|
+  t.references :<%= table_prefix %>, foreign_key: true<%= primary_key_type(:type) %>
+  t.string :password_hash, null: false
+end

--- a/lib/rodauth/rack/generators/migration/active_record/email_auth.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/email_auth.erb
@@ -1,0 +1,8 @@
+# Used by the email auth feature
+create_table :<%= table_prefix %>_email_auth_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.datetime :deadline, null: false
+  t.datetime :email_last_sent, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/jwt_refresh.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/jwt_refresh.erb
@@ -1,0 +1,6 @@
+# Used by the jwt refresh feature
+create_table :<%= table_prefix %>_jwt_refresh_keys<%= primary_key_type %> do |t|
+  t.references :<%= table_prefix %>, foreign_key: true, null: false<%= primary_key_type(:type) %>
+  t.string :key, null: false
+  t.datetime :deadline, null: false
+end

--- a/lib/rodauth/rack/generators/migration/active_record/lockout.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/lockout.erb
@@ -1,0 +1,13 @@
+# Used by the lockout feature
+create_table :<%= table_prefix %>_login_failures, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.integer :number, null: false, default: 1
+end
+create_table :<%= table_prefix %>_lockouts, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.datetime :deadline, null: false
+  t.datetime :email_last_sent
+end

--- a/lib/rodauth/rack/generators/migration/active_record/otp.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/otp.erb
@@ -1,0 +1,8 @@
+# Used by the otp feature
+create_table :<%= table_prefix %>_otp_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.integer :num_failures, null: false, default: 0
+  t.datetime :last_use, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/otp_unlock.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/otp_unlock.erb
@@ -1,0 +1,7 @@
+# Used by the otp_unlock feature
+create_table :<%= table_prefix %>_otp_unlocks, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.integer :num_successes, null: false, default: 1
+  t.datetime :next_auth_attempt_after, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/password_expiration.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/password_expiration.erb
@@ -1,0 +1,6 @@
+# Used by the password expiration feature
+create_table :<%= table_prefix %>_password_change_times, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.datetime :changed_at, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/recovery_codes.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/recovery_codes.erb
@@ -1,0 +1,6 @@
+# Used by the recovery codes feature
+create_table :<%= table_prefix %>_recovery_codes, primary_key: [:id, :code] do |t|
+  t.<%= primary_key_type(nil) %> :id
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :code
+end

--- a/lib/rodauth/rack/generators/migration/active_record/remember.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/remember.erb
@@ -1,0 +1,7 @@
+# Used by the remember me feature
+create_table :<%= table_prefix %>_remember_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.datetime :deadline, null: false
+end

--- a/lib/rodauth/rack/generators/migration/active_record/reset_password.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/reset_password.erb
@@ -1,0 +1,8 @@
+# Used by the password reset feature
+create_table :<%= table_prefix %>_password_reset_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.datetime :deadline, null: false
+  t.datetime :email_last_sent, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/single_session.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/single_session.erb
@@ -1,0 +1,6 @@
+# Used by the single session feature
+create_table :<%= table_prefix %>_session_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+end

--- a/lib/rodauth/rack/generators/migration/active_record/sms_codes.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/sms_codes.erb
@@ -1,0 +1,9 @@
+# Used by the sms codes feature
+create_table :<%= table_prefix %>_sms_codes, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :phone_number, null: false
+  t.integer :num_failures
+  t.string :code
+  t.datetime :code_issued_at, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/verify_account.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/verify_account.erb
@@ -1,0 +1,8 @@
+# Used by the account verification feature
+create_table :<%= table_prefix %>_verification_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.datetime :requested_at, null: false, default: -> { "<%= current_timestamp %>" }
+  t.datetime :email_last_sent, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/active_record/verify_login_change.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/verify_login_change.erb
@@ -1,0 +1,8 @@
+# Used by the verify login change feature
+create_table :<%= table_prefix %>_login_change_keys, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :key, null: false
+  t.string :login, null: false
+  t.datetime :deadline, null: false
+end

--- a/lib/rodauth/rack/generators/migration/active_record/webauthn.erb
+++ b/lib/rodauth/rack/generators/migration/active_record/webauthn.erb
@@ -1,0 +1,13 @@
+# Used by the webauthn feature
+create_table :<%= table_prefix %>_webauthn_user_ids, id: false do |t|
+  t.<%= primary_key_type(nil) %> :id, primary_key: true
+  t.foreign_key :<%= table_prefix.pluralize %>, column: :id
+  t.string :webauthn_id, null: false
+end
+create_table :<%= table_prefix %>_webauthn_keys, primary_key: [:<%= table_prefix %>_id, :webauthn_id] do |t|
+  t.references :<%= table_prefix %>, foreign_key: true<%= primary_key_type(:type) %>
+  t.string :webauthn_id
+  t.string :public_key, null: false
+  t.integer :sign_count, null: false
+  t.datetime :last_use, null: false, default: -> { "<%= current_timestamp %>" }
+end

--- a/lib/rodauth/rack/generators/migration/sequel/account_expiration.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/account_expiration.erb
@@ -1,0 +1,7 @@
+# Used by the account expiration feature
+create_table :<%= table_prefix %>_activity_times do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  DateTime :last_activity_at, null: false
+  DateTime :last_login_at, null: false
+  DateTime :expired_at
+end

--- a/lib/rodauth/rack/generators/migration/sequel/active_sessions.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/active_sessions.erb
@@ -1,0 +1,8 @@
+# Used by the active sessions feature
+create_table :<%= table_prefix %>_active_session_keys do
+  foreign_key :<%= table_prefix %>_id, :<%= table_prefix.pluralize %>, type: :Bignum
+  String :session_id
+  Time :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+  Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
+  primary_key [:<%= table_prefix %>_id, :session_id]
+end

--- a/lib/rodauth/rack/generators/migration/sequel/audit_logging.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/audit_logging.erb
@@ -1,0 +1,17 @@
+# Used by the audit logging feature
+create_table :<%= table_prefix %>_authentication_audit_logs do
+  primary_key :id, type: :Bignum
+  foreign_key :<%= table_prefix %>_id, :<%= table_prefix.pluralize %>, null: false, type: :Bignum
+  DateTime :at, null: false, default: Sequel::CURRENT_TIMESTAMP
+  String :message, null: false
+<% case db.database_type -%>
+<% when :postgres -%>
+  jsonb :metadata
+<% when :sqlite, :mysql -%>
+  json :metadata
+<% else -%>
+  String :metadata
+<% end -%>
+  index [:<%= table_prefix %>_id, :at]
+  index :at
+end

--- a/lib/rodauth/rack/generators/migration/sequel/base.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/base.erb
@@ -1,0 +1,23 @@
+<% if db.database_type == :postgres -%>
+begin
+  run "CREATE EXTENSION IF NOT EXISTS citext"
+rescue NoMethodError # migration is being reverted
+end
+
+<% end -%>
+create_table :<%= table_prefix.pluralize %> do
+  primary_key :id, type: :Bignum
+<% if db.database_type == :postgres -%>
+  citext :email, null: false
+  constraint :valid_email, email: /^[^,;@ \r\n]+@[^,@; \r\n]+\.[^,@; \r\n]+$/
+<% else -%>
+  String :email, null: false
+<% end -%>
+  Integer :status, null: false, default: 1
+<% if db.supports_partial_indexes? -%>
+  index :email, unique: true, where: { status: [1, 2] }
+<% else -%>
+  index :email, unique: true
+<% end -%>
+  String :password_hash
+end

--- a/lib/rodauth/rack/generators/migration/sequel/disallow_password_reuse.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/disallow_password_reuse.erb
@@ -1,0 +1,6 @@
+# Used by the disallow password reuse feature
+create_table :<%= table_prefix %>_previous_password_hashes do
+  primary_key :id, type: :Bignum
+  foreign_key :<%= table_prefix %>_id, :<%= table_prefix.pluralize %>, type: :Bignum
+  String :password_hash, null: false
+end

--- a/lib/rodauth/rack/generators/migration/sequel/email_auth.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/email_auth.erb
@@ -1,0 +1,7 @@
+# Used by the email auth feature
+create_table :<%= table_prefix %>_email_auth_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  DateTime :deadline, null: false
+  DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/jwt_refresh.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/jwt_refresh.erb
@@ -1,0 +1,8 @@
+# Used by the jwt refresh feature
+create_table :<%= table_prefix %>_jwt_refresh_keys do
+  primary_key :id, type: :Bignum
+  foreign_key :<%= table_prefix %>_id, :<%= table_prefix.pluralize %>, null: false, type: :Bignum
+  String :key, null: false
+  DateTime :deadline, null: false
+  index :<%= table_prefix %>_id
+end

--- a/lib/rodauth/rack/generators/migration/sequel/lockout.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/lockout.erb
@@ -1,0 +1,11 @@
+# Used by the lockout feature
+create_table :<%= table_prefix %>_login_failures do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  Integer :number, null: false, default: 1
+end
+create_table :<%= table_prefix %>_lockouts do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  DateTime :deadline, null: false
+  DateTime :email_last_sent
+end

--- a/lib/rodauth/rack/generators/migration/sequel/otp.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/otp.erb
@@ -1,0 +1,7 @@
+# Used by the otp feature
+create_table :<%= table_prefix %>_otp_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  Integer :num_failures, null: false, default: 0
+  Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/otp_unlock.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/otp_unlock.erb
@@ -1,0 +1,6 @@
+# Used by the otp_unlock feature
+create_table :<%= table_prefix %>_otp_unlocks do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  Integer :num_successes, null: false, default: 1
+  Time :next_auth_attempt_after, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/password_expiration.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/password_expiration.erb
@@ -1,0 +1,5 @@
+# Used by the password expiration feature
+create_table :<%= table_prefix %>_password_change_times do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  DateTime :changed_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/recovery_codes.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/recovery_codes.erb
@@ -1,0 +1,6 @@
+# Used by the recovery codes feature
+create_table :<%= table_prefix %>_recovery_codes do
+  foreign_key :id, :<%= table_prefix.pluralize %>, type: :Bignum
+  String :code
+  primary_key [:id, :code]
+end

--- a/lib/rodauth/rack/generators/migration/sequel/remember.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/remember.erb
@@ -1,0 +1,6 @@
+# Used by the remember me feature
+create_table :<%= table_prefix %>_remember_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  DateTime :deadline, null: false
+end

--- a/lib/rodauth/rack/generators/migration/sequel/reset_password.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/reset_password.erb
@@ -1,0 +1,7 @@
+# Used by the password reset feature
+create_table :<%= table_prefix %>_password_reset_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  DateTime :deadline, null: false
+  DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/single_session.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/single_session.erb
@@ -1,0 +1,5 @@
+# Used by the single session feature
+create_table :<%= table_prefix %>_session_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+end

--- a/lib/rodauth/rack/generators/migration/sequel/sms_codes.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/sms_codes.erb
@@ -1,0 +1,8 @@
+# Used by the sms codes feature
+create_table :<%= table_prefix %>_sms_codes do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :phone_number, null: false
+  Integer :num_failures
+  String :code
+  DateTime :code_issued_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/verify_account.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/verify_account.erb
@@ -1,0 +1,7 @@
+# Used by the account verification feature
+create_table :<%= table_prefix %>_verification_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  DateTime :requested_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+  DateTime :email_last_sent, null: false, default: Sequel::CURRENT_TIMESTAMP
+end

--- a/lib/rodauth/rack/generators/migration/sequel/verify_login_change.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/verify_login_change.erb
@@ -1,0 +1,7 @@
+# Used by the verify login change feature
+create_table :<%= table_prefix %>_login_change_keys do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :key, null: false
+  String :login, null: false
+  DateTime :deadline, null: false
+end

--- a/lib/rodauth/rack/generators/migration/sequel/webauthn.erb
+++ b/lib/rodauth/rack/generators/migration/sequel/webauthn.erb
@@ -1,0 +1,13 @@
+# Used by the webauthn feature
+create_table :<%= table_prefix %>_webauthn_user_ids do
+  foreign_key :id, :<%= table_prefix.pluralize %>, primary_key: true, type: :Bignum
+  String :webauthn_id, null: false
+end
+create_table :<%= table_prefix %>_webauthn_keys do
+  foreign_key :<%= table_prefix %>_id, :<%= table_prefix.pluralize %>, type: :Bignum
+  String :webauthn_id
+  String :public_key, null: false
+  Integer :sign_count, null: false
+  Time :last_use, null: false, default: Sequel::CURRENT_TIMESTAMP
+  primary_key [:<%= table_prefix %>_id, :webauthn_id]
+end

--- a/spec/rodauth/rack/generators/migration_spec.rb
+++ b/spec/rodauth/rack/generators/migration_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Rodauth::Rack::Generators::Migration do
+  describe "#initialize" do
+    it "accepts features as an array" do
+      generator = described_class.new(features: [:base, :verify_account])
+      expect(generator.features).to eq([:base, :verify_account])
+    end
+
+    it "converts features to symbols" do
+      generator = described_class.new(features: ["base", "otp"])
+      expect(generator.features).to eq([:base, :otp])
+    end
+
+    it "defaults to sequel ORM" do
+      generator = described_class.new(features: [:base])
+      expect(generator.orm).to eq(:sequel)
+    end
+
+    it "accepts custom ORM" do
+      generator = described_class.new(features: [:base], orm: :active_record)
+      expect(generator.orm).to eq(:active_record)
+    end
+
+    it "accepts custom prefix" do
+      generator = described_class.new(features: [:base], prefix: "user")
+      expect(generator.prefix).to eq("user")
+    end
+
+    it "accepts database adapter" do
+      generator = described_class.new(features: [:base], db_adapter: :postgresql)
+      expect(generator.db_adapter).to eq(:postgresql)
+    end
+
+    it "raises error when no features specified" do
+      expect {
+        described_class.new(features: [])
+      }.to raise_error(ArgumentError, /No features specified/)
+    end
+
+    it "raises error for invalid ORM" do
+      expect {
+        described_class.new(features: [:base], orm: :mongoid)
+      }.to raise_error(ArgumentError, /Invalid ORM/)
+    end
+  end
+
+  describe "#configuration" do
+    it "returns configuration for base feature" do
+      generator = described_class.new(features: [:base], prefix: "account")
+      config = generator.configuration
+
+      expect(config).to eq(accounts_table: "accounts")
+    end
+
+    it "returns configuration for multiple features" do
+      generator = described_class.new(features: [:base, :remember], prefix: "account")
+      config = generator.configuration
+
+      expect(config).to include(
+        accounts_table: "accounts",
+        remember_table: "account_remember_keys"
+      )
+    end
+
+    it "handles custom table prefix" do
+      generator = described_class.new(features: [:base, :otp], prefix: "user")
+      config = generator.configuration
+
+      expect(config).to include(
+        accounts_table: "users",
+        otp_keys_table: "user_otp_keys"
+      )
+    end
+
+    it "includes all configuration for webauthn feature" do
+      generator = described_class.new(features: [:webauthn], prefix: "account")
+      config = generator.configuration
+
+      expect(config).to include(
+        webauthn_keys_table: "account_webauthn_keys",
+        webauthn_user_ids_table: "account_webauthn_user_ids",
+        webauthn_keys_account_id_column: "account_id"
+      )
+    end
+
+    it "includes all configuration for lockout feature" do
+      generator = described_class.new(features: [:lockout], prefix: "account")
+      config = generator.configuration
+
+      expect(config).to include(
+        account_login_failures_table: "account_login_failures",
+        account_lockouts_table: "account_lockouts"
+      )
+    end
+  end
+
+  describe "#migration_name" do
+    it "generates migration name with default prefix" do
+      generator = described_class.new(features: [:base, :verify_account])
+      expect(generator.migration_name).to eq("create_rodauth_base_verify_account")
+    end
+
+    it "generates migration name with custom prefix" do
+      generator = described_class.new(features: [:base], prefix: "user")
+      expect(generator.migration_name).to eq("create_rodauth_user_base")
+    end
+
+    it "generates migration name for single feature" do
+      generator = described_class.new(features: [:otp])
+      expect(generator.migration_name).to eq("create_rodauth_otp")
+    end
+  end
+
+  describe "#generate" do
+    context "with Sequel ORM" do
+      it "generates migration for base feature" do
+        generator = described_class.new(features: [:base], orm: :sequel)
+        migration = generator.generate
+
+        expect(migration).to include("create_table :accounts")
+        expect(migration).to include("primary_key :id")
+        expect(migration).to include("Integer :status")
+        expect(migration).to include("String :password_hash")
+      end
+
+      it "generates migration for verify_account feature" do
+        generator = described_class.new(features: [:verify_account], orm: :sequel)
+        migration = generator.generate
+
+        expect(migration).to include("create_table :account_verification_keys")
+      end
+
+      it "generates migration for multiple features" do
+        generator = described_class.new(features: [:base, :remember], orm: :sequel)
+        migration = generator.generate
+
+        expect(migration).to include("create_table :accounts")
+        expect(migration).to include("create_table :account_remember_keys")
+      end
+
+      it "uses custom table prefix" do
+        generator = described_class.new(features: [:base], orm: :sequel, prefix: "user")
+        migration = generator.generate
+
+        expect(migration).to include("create_table :users")
+      end
+    end
+
+    context "with ActiveRecord ORM" do
+      it "generates migration for base feature" do
+        generator = described_class.new(features: [:base], orm: :active_record)
+        migration = generator.generate
+
+        expect(migration).to include("create_table :accounts")
+        expect(migration).to include("t.integer :status")
+        expect(migration).to include("t.string :password_hash")
+      end
+
+      it "generates migration for verify_account feature" do
+        generator = described_class.new(features: [:verify_account], orm: :active_record)
+        migration = generator.generate
+
+        expect(migration).to include("create_table :account_verification_keys")
+      end
+
+      it "generates migration with PostgreSQL adapter" do
+        generator = described_class.new(
+          features: [:base],
+          orm: :active_record,
+          db_adapter: :postgresql
+        )
+        migration = generator.generate
+
+        expect(migration).to include('enable_extension "citext"')
+        expect(migration).to include("t.citext :email")
+      end
+
+      it "generates migration with MySQL adapter" do
+        generator = described_class.new(
+          features: [:base],
+          orm: :active_record,
+          db_adapter: :mysql2
+        )
+        migration = generator.generate
+
+        expect(migration).to include("t.string :email")
+        expect(migration).not_to include("citext")
+      end
+
+      it "generates migration with SQLite adapter" do
+        generator = described_class.new(
+          features: [:base],
+          orm: :active_record,
+          db_adapter: :sqlite3
+        )
+        migration = generator.generate
+
+        expect(migration).to include("t.string :email")
+      end
+    end
+
+    context "with invalid features" do
+      it "raises error for unknown feature" do
+        expect {
+          described_class.new(features: [:unknown_feature])
+        }.to raise_error(ArgumentError, /No migration template/)
+      end
+    end
+  end
+
+  describe "all available features" do
+    let(:all_features) do
+      [
+        :base, :remember, :verify_account, :verify_login_change,
+        :reset_password, :email_auth, :otp, :otp_unlock, :sms_codes,
+        :recovery_codes, :webauthn, :lockout, :active_sessions,
+        :account_expiration, :password_expiration, :single_session,
+        :audit_logging, :disallow_password_reuse, :jwt_refresh
+      ]
+    end
+
+    it "has templates for all 19 features in ActiveRecord" do
+      all_features.each do |feature|
+        expect {
+          described_class.new(features: [feature], orm: :active_record)
+        }.not_to raise_error
+      end
+    end
+
+    it "has templates for all 19 features in Sequel" do
+      all_features.each do |feature|
+        expect {
+          described_class.new(features: [feature], orm: :sequel)
+        }.not_to raise_error
+      end
+    end
+
+    it "has configuration for all features" do
+      all_features.each do |feature|
+        generator = described_class.new(features: [feature])
+        expect(generator.configuration).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to #1 #2

This PR implements the core migration generator system for rodauth-rack, providing framework-agnostic database migration generation for all 19 Rodauth authentication features.

## What's New

The generator system allows any Rack framework to generate Rodauth database migrations with a simple Ruby API:

```ruby
generator = Rodauth::Rack::Generators::Migration.new(
  features: [:base, :verify_account, :otp],
  orm: :sequel,
  prefix: "account"
)

puts generator.generate      # migration content
puts generator.configuration # Rodauth config hash
```

This works identically whether you're using Rails, Hanami, Sinatra, Roda, or any other Rack framework.

## Implementation Details

**Migration Templates** (38 files)
- 19 ActiveRecord ERB templates in `lib/rodauth/rack/generators/migration/active_record/`
- 19 Sequel ERB templates in `lib/rodauth/rack/generators/migration/sequel/`
- All templates copied from rodauth-rails with minimal modifications for framework independence
- Database-specific optimizations for PostgreSQL (citext, jsonb, partial indexes), MySQL (CURRENT_TIMESTAMP precision), and SQLite3 (integer vs bigint primary keys)

**Generator Class** (`lib/rodauth/rack/generators/migration.rb`)
- Framework-agnostic API that works with any Rack framework
- Validates features and ORM selection
- Evaluates ERB templates with proper bindings
- Generates Rodauth configuration from selected features
- Simplified String#pluralize/singularize (production will use ActiveSupport or similar)

**Supported Features**
All 19 Rodauth database features: base accounts, remember me, account/login verification, password reset, email auth, OTP/SMS/recovery codes, WebAuthn, lockout, active sessions, account/password expiration, single session, audit logging, password history, JWT refresh tokens.

## Documentation

Updated README with:
- Migration generator usage examples for both ORMs
- Complete list of 19 supported features with descriptions
- Attribution to rodauth-rails (MIT licensed source)
- AI development transparency note

## Attribution

All migration templates are copied from [rodauth-rails](https://github.com/janko/rodauth-rails) by Janko Marohnić, released under the MIT License. The generator architecture follows rodauth-rails' proven design patterns. Attribution and license information added to README.

## Next Steps

This establishes the foundation for framework-specific integrations:
- Rails adapter will wrap this with Rails generators
- Hanami adapter will provide CLI commands
- CLI tool for Roda/Sinatra will use this directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>