### PR TITLE
Extract shared secret guard logic into Rodauth::SecretGuard module

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 514
+  Max: 524
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
@@ -69,7 +69,7 @@ Metrics/MethodLength:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 516
+  Max: 526
 
 # Offense count: 10
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -108,6 +108,7 @@ RSpec/DescribeClass:
     - '**/spec/views/**/*'
     - 'spec/rodauth/features/external_identity/external_identity_spec.rb'
     - 'spec/rodauth/features/external_identity_autocreate_integration_spec.rb'
+    - 'spec/rodauth/features/secret_guard_combined_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_integration_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_spec.rb'
@@ -204,6 +205,7 @@ Style/SafeNavigation:
     - 'spec/rodauth/features/external_identity_autocreate_integration_spec.rb'
     - 'spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb'
     - 'spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb'
+    - 'spec/rodauth/features/secret_guard_combined_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
 
 # Offense count: 1
@@ -231,6 +233,7 @@ Style/SymbolProc:
     - 'spec/rodauth/features/external_identity_autocreate_integration_spec.rb'
     - 'spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb'
     - 'spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb'
+    - 'spec/rodauth/features/secret_guard_combined_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_integration_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
     - 'try/features/external_identity_try.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 509
+  Max: 514
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
@@ -69,7 +69,7 @@ Metrics/MethodLength:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 511
+  Max: 516
 
 # Offense count: 10
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,21 +42,30 @@ bin/console
 - Uses `Rodauth::Feature.define(:hmac_secret_guard, :HmacSecretGuard)` pattern
 - Automatically loads HMAC secret from environment variable (defaults to `HMAC_SECRET`)
 - Validates secret is configured at application startup via `post_configure` hook
-- Production mode: Raises `ConfigurationError` if secret missing
-- Development mode: Logs warning and uses configurable fallback secret
-- Deletes secret from ENV after loading for security
-- Provides `production?` and `validate_secrets!` public methods
+- Production mode: Raises `ConfigurationError` if secret missing, blank, or (when `minimum_secret_length` is set) too short
+- Development mode: Logs warning and uses a fallback secret (random per-process by default)
+- Deletes secret from ENV after loading for security (strips whitespace; blank values treated as absent)
+- Provides `production?`, `validate_hmac_secret!`, and (aliased) `validate_secrets!` public methods
 
 **lib/rodauth/features/jwt_secret_guard.rb** - External Rodauth feature
 
 - Uses `Rodauth::Feature.define(:jwt_secret_guard, :JwtSecretGuard)` pattern
 - Automatically loads JWT secret from environment variable (defaults to `JWT_SECRET`)
 - Validates secret is configured at application startup via `post_configure` hook
-- Production mode: Raises `ConfigurationError` if secret missing
-- Development mode: Logs warning and uses configurable fallback secret
-- Deletes secret from ENV after loading for security
-- Provides `production?` and `validate_secrets!` public methods
+- Production mode: Raises `ConfigurationError` if secret missing, blank, or (when `minimum_secret_length` is set) too short
+- Development mode: Logs warning and uses a fallback secret (random per-process by default)
+- Deletes secret from ENV after loading for security (strips whitespace; blank values treated as absent)
+- Provides `production?`, `validate_jwt_secret!`, and (aliased) `validate_secrets!` public methods
 - Defines `jwt_secret` configuration method for standalone use
+
+**lib/rodauth/secret_guard.rb** - Shared support module (`Rodauth::SecretGuard`)
+
+- Kind-parameterized (`:hmac`/`:jwt`) logic behind both secret-guard features
+- Plain module functions taking the Rodauth instance explicitly — no mixed-in
+  method names, so both guards can be enabled together without one shadowing the
+  other (each feature's `post_configure` validates its own secret via `kind`)
+- Handles ENV loading (`load_from_env!`), validation (`validate!`), blank/whitespace
+  detection, production detection, and minimum-length enforcement
 
 **lib/rodauth/tools/migration.rb** - Sequel migration generator
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ end
 
 ### Table Guard Implementation Details
 
-**Logger Suppression:** The `table_exists?` method temporarily suppresses Sequel's logger during table existence checks. This prevents confusing ERROR logs from Sequel when checking non-existent tables (Sequel's `table_exists?` attempts a SELECT and logs the exception before catching it).
+**Existence Checks (no logger suppression):** The `table_exists?` method matches names against the database's table/view list (`db.tables` + `db.views`) rather than probing each table with a SELECT. An earlier implementation used Sequel's `table_exists?` probe and suppressed the logger around it (clearing/restoring the shared `db.loggers` array) to hide the "no such table" ERROR that Sequel logs before catching internally — but that mutation of shared connection state was not thread-safe. Listing names avoids the failed probe entirely, so no logger suppression (and no shared-state mutation) is needed. Schema-qualified identifiers (a `Sequel::SQL::QualifiedIdentifier` or a `:schema__table` Symbol) are not present in the unqualified list, so they take a separate schema-aware `db.table_exists?` probe path.
 
 **Configuration Storage:** Uses instance variables set by `auth_value_method`:
 
@@ -138,7 +138,7 @@ end
 **Introspection Methods:**
 
 - `all_table_methods` - Finds all methods ending in `_table` using Ruby reflection
-- `missing_tables` - Checks each table method against `db.table_exists?`
+- `missing_tables` - Checks each required table against the existing table/view name set (fetched once per pass to avoid an N+1 of catalog queries)
 - `table_status` - Returns array of hashes with method, table name, and existence status
 
 ### Migration Generator Architecture

--- a/docs/features/hmac-secret-guard.md
+++ b/docs/features/hmac-secret-guard.md
@@ -623,9 +623,11 @@ A minimum length is available out of the box via `minimum_secret_length`
 (production only). For anything beyond that, override the kind-specific
 `validate_hmac_secret!` method in your configuration.
 
-> **Note:** `validate_hmac_secret!` does not accept a block. Override the method
-> (not `validate_secrets!`, which is a shared alias) so it keeps working when
-> `jwt_secret_guard` is also enabled.
+> **Note:** `validate_hmac_secret!` does not take a block when *called* at
+> runtime. To customize validation, *override* the method in your configuration
+> (the block form shown below is the Rodauth config-DSL override, not a runtime
+> call). Override `validate_hmac_secret!` — not `validate_secrets!`, which is a
+> shared alias — so it keeps working when `jwt_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do

--- a/docs/features/hmac-secret-guard.md
+++ b/docs/features/hmac-secret-guard.md
@@ -28,9 +28,13 @@ Determines if application is running in production mode.
 
 **Default:** `proc { ENV.fetch('RACK_ENV', 'production') == 'production' }`
 
+The default **fails safe**: an unset `RACK_ENV` is treated as production, so a
+misconfigured deploy raises instead of silently using the development fallback
+secret.
+
 ```ruby
-# Proc - dynamic check
-production_env_check proc { ENV['RACK_ENV'] == 'production' }
+# Proc - dynamic check (fail-safe: unset RACK_ENV counts as production)
+production_env_check proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
 
 # Boolean - static value
 production_env_check true
@@ -40,6 +44,10 @@ production_env_check proc {
   ENV['RAILS_ENV'] == 'production' || ENV['DEPLOYMENT_ENV'] == 'staging'
 }
 ```
+
+> **Avoid** `proc { ENV['RACK_ENV'] == 'production' }`. When `RACK_ENV` is unset
+> that returns `false`, so a real production deploy is treated as development and
+> silently falls back to the insecure development secret.
 
 ### `validate_secrets_on_configure?`
 
@@ -53,12 +61,28 @@ validate_secrets_on_configure? false  # Disable validation
 
 ### `development_hmac_secret_fallback`
 
-Fallback HMAC secret for development environments.
+Fallback HMAC secret used in development when no secret is configured.
 
-**Default:** `'dev-only-insecure-example-hmac-secret-needs-to-be-changed-in-prod'`
+**Default:** a random per-process value (`SecureRandom.hex(32)`).
+
+The default is generated once per process rather than being a constant baked
+into source. It is therefore never publicly known and is unstable across
+restarts, so it can't be mistaken for a real, persistent secret. Set an explicit
+value only if you need HMAC output to be stable across restarts in development.
 
 ```ruby
 development_hmac_secret_fallback 'my-custom-dev-secret-12345'
+```
+
+### `minimum_secret_length`
+
+Minimum length required for a configured secret. Enforced **in production only**,
+so development fallbacks and short test secrets are unaffected.
+
+**Default:** `0` (disabled)
+
+```ruby
+minimum_secret_length 32  # reject secrets shorter than 32 chars in production
 ```
 
 ### `hmac_secret_missing_error`
@@ -154,7 +178,7 @@ end
 
 1. **Check existing hmac_secret**
    - If already set via configuration block, skip auto-configuration
-   - If nil or empty, proceed to step 2
+   - If nil, empty, or whitespace-only, proceed to step 2
 
 2. **Read from environment variable**
    - Read value from `HMAC_SECRET` (or configured env key)
@@ -191,15 +215,31 @@ Logs warning to logger (if available) or stderr, then uses `development_hmac_sec
 
 ## Public Methods
 
+### `validate_hmac_secret!`
+
+Manually trigger HMAC secret validation. This is the collision-free entry
+point — prefer it when both `hmac_secret_guard` and `jwt_secret_guard` are
+enabled.
+
+```ruby
+rodauth.validate_hmac_secret!
+# Raises error in production if the secret is missing, blank, or too short
+# Sets a fallback in development if the secret is missing
+```
+
 ### `validate_secrets!`
 
-Manually trigger secret validation.
+Backwards-compatible alias for `validate_hmac_secret!`.
 
 ```ruby
 rodauth.validate_secrets!
-# Raises error in production if secret missing
-# Sets fallback in development if secret missing
 ```
+
+> **Note:** `jwt_secret_guard` defines a `validate_secrets!` of its own. When
+> both guards are enabled this shared name resolves to only one of them, so use
+> the kind-specific `validate_hmac_secret!` / `validate_jwt_secret!` for an
+> unambiguous manual call. Boot-time validation does not rely on the alias —
+> each feature's `post_configure` validates its own secret independently.
 
 ### `production?`
 
@@ -518,7 +558,8 @@ Validation runs in `post_configure` hook:
 ```ruby
 def post_configure
   super
-  validate_secrets! if validate_secrets_on_configure?
+  Rodauth::SecretGuard.load_from_env!(self, :hmac)
+  validate_hmac_secret! if validate_secrets_on_configure?
 end
 ```
 
@@ -532,42 +573,38 @@ end
 
 ### Multiple Secrets
 
-Guard multiple secrets by calling the feature with different configurations:
+To guard both the HMAC and JWT secrets, enable both features. They share
+kind-keyed logic (`Rodauth::SecretGuard`), so each secret is validated
+independently at boot:
 
 ```ruby
 plugin :rodauth do
-  enable :hmac_secret_guard
-
-  # Validate hmac_secret
-  validate_secrets!
-
-  # Also validate jwt_secret if using JWT
-  if respond_to?(:jwt_secret)
-    unless jwt_secret
-      raise Rodauth::ConfigurationError, "JWT_SECRET must be set"
-    end
-  end
+  enable :hmac_secret_guard, :jwt_secret_guard
+  # Both HMAC_SECRET and JWT_SECRET are validated in post_configure
 end
 ```
 
 ### Custom Validation Logic
 
-> **Note:** `validate_secrets!` does not accept a block. To add custom validation logic, override the `validate_secrets!` method in your configuration.
+A minimum length is available out of the box via `minimum_secret_length`
+(production only). For anything beyond that, override the kind-specific
+`validate_hmac_secret!` method in your configuration.
+
+> **Note:** `validate_hmac_secret!` does not accept a block. Override the method
+> (not `validate_secrets!`, which is a shared alias) so it keeps working when
+> `jwt_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do
   enable :hmac_secret_guard
 
-  # Override validate_secrets! to add custom checks
-  validate_secrets! do
+  minimum_secret_length 64  # enforced in production
+
+  # Override for additional checks
+  validate_hmac_secret! do
     super() # Call the original validation
 
     secret = hmac_secret
-
-    # Custom length requirement
-    if secret && secret.length < 64
-      raise Rodauth::ConfigurationError, "HMAC secret must be at least 64 characters"
-    end
 
     # Custom entropy check
     if secret && secret.chars.uniq.length < 16

--- a/docs/features/hmac-secret-guard.md
+++ b/docs/features/hmac-secret-guard.md
@@ -70,6 +70,18 @@ into source. It is therefore never publicly known and is unstable across
 restarts, so it can't be mistaken for a real, persistent secret. Set an explicit
 value only if you need HMAC output to be stable across restarts in development.
 
+> **Caution — multi-process and multi-host environments.** Because the default
+> fallback is generated per process and at random, it is **not** shared across
+> processes or hosts and changes on every restart. Any tokens derived from
+> `hmac_secret` — password-reset links, remember-me tokens, and similar — become
+> invalid after a restart, and in a load-balanced or multi-instance deployment a
+> token minted by one instance fails on another (each process holds a different
+> fallback). This most often bites review apps, staging, CI, and load-balanced
+> development where `RACK_ENV` is not `production` yet more than one process is
+> involved. In those environments, set an explicit, stable
+> `development_hmac_secret_fallback` (or provide a real `HMAC_SECRET`) rather than
+> relying on the random default.
+
 ```ruby
 development_hmac_secret_fallback 'my-custom-dev-secret-12345'
 ```
@@ -190,6 +202,14 @@ end
    - Production: Raise error if missing
    - Development: Warn and use fallback
 
+> **Note:** Secrets read from the environment variable are whitespace-trimmed —
+> leading and trailing whitespace is stripped, so `HMAC_SECRET=" abc\n"` becomes
+> `"abc"` (this tolerates the trailing newlines common in `.env` files). A value
+> that is entirely whitespace is treated as **absent**, triggering the production
+> error or the development fallback. Secrets set directly via the `hmac_secret`
+> DSL are used verbatim, though the `minimum_secret_length` check measures their
+> length after stripping.
+
 ### Production Mode
 
 When `production?` returns true:
@@ -239,7 +259,10 @@ rodauth.validate_secrets!
 > both guards are enabled this shared name resolves to only one of them, so use
 > the kind-specific `validate_hmac_secret!` / `validate_jwt_secret!` for an
 > unambiguous manual call. Boot-time validation does not rely on the alias —
-> each feature's `post_configure` validates its own secret independently.
+> each feature's `post_configure` validates its own secret independently. The
+> same applies when **overriding** validation: with both guards enabled, override
+> the kind-specific `validate_hmac_secret!` (not `validate_secrets!`), or your
+> override will silently apply to only one of the two secrets.
 
 ### `production?`
 
@@ -583,6 +606,16 @@ plugin :rodauth do
   # Both HMAC_SECRET and JWT_SECRET are validated in post_configure
 end
 ```
+
+> **Shared vs. kind-specific settings.** When both guards are enabled,
+> `minimum_secret_length`, `production_env_check`, and
+> `validate_secrets_on_configure?` are each defined by both features under the
+> same name and are therefore **shared** — you set each once and it applies to
+> **both** secrets; you cannot give HMAC and JWT different values for these. The
+> env key, error messages, and fallback are kind-specific, so they can differ per
+> secret: `hmac_secret_env_key` vs `jwt_secret_env_key`,
+> `hmac_secret_missing_error` vs `jwt_secret_missing_error`, and
+> `development_hmac_secret_fallback` vs `development_jwt_secret_fallback`.
 
 ### Custom Validation Logic
 

--- a/docs/features/jwt-secret-guard.md
+++ b/docs/features/jwt-secret-guard.md
@@ -28,9 +28,13 @@ Determines if application is running in production mode.
 
 **Default:** `proc { ENV.fetch('RACK_ENV', 'production') == 'production' }`
 
+The default **fails safe**: an unset `RACK_ENV` is treated as production, so a
+misconfigured deploy raises instead of silently using the development fallback
+secret.
+
 ```ruby
-# Proc - dynamic check
-production_env_check proc { ENV['RACK_ENV'] == 'production' }
+# Proc - dynamic check (fail-safe: unset RACK_ENV counts as production)
+production_env_check proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
 
 # Boolean - static value
 production_env_check true
@@ -40,6 +44,10 @@ production_env_check proc {
   ENV['RAILS_ENV'] == 'production' || ENV['DEPLOYMENT_ENV'] == 'staging'
 }
 ```
+
+> **Avoid** `proc { ENV['RACK_ENV'] == 'production' }`. When `RACK_ENV` is unset
+> that returns `false`, so a real production deploy is treated as development and
+> silently falls back to the insecure development secret.
 
 ### `validate_secrets_on_configure?`
 
@@ -53,12 +61,28 @@ validate_secrets_on_configure? false  # Disable validation
 
 ### `development_jwt_secret_fallback`
 
-Fallback JWT secret for development environments.
+Fallback JWT secret used in development when no secret is configured.
 
-**Default:** `'dev-only-insecure-example-jwt-secret-needs-to-be-changed-in-prod'`
+**Default:** a random per-process value (`SecureRandom.hex(32)`).
+
+The default is generated once per process rather than being a constant baked
+into source. It is therefore never publicly known and is unstable across
+restarts, so it can't be mistaken for a real, persistent secret. Set an explicit
+value only if you need JWTs to remain valid across restarts in development.
 
 ```ruby
 development_jwt_secret_fallback 'my-custom-dev-secret-12345'
+```
+
+### `minimum_secret_length`
+
+Minimum length required for a configured secret. Enforced **in production only**,
+so development fallbacks and short test secrets are unaffected.
+
+**Default:** `0` (disabled)
+
+```ruby
+minimum_secret_length 32  # reject secrets shorter than 32 chars in production
 ```
 
 ### `jwt_secret_missing_error`
@@ -154,7 +178,7 @@ end
 
 1. **Check existing jwt_secret**
    - If already set via configuration block, skip auto-configuration
-   - If nil or empty, proceed to step 2
+   - If nil, empty, or whitespace-only, proceed to step 2
 
 2. **Read from environment variable**
    - Read value from `JWT_SECRET` (or configured env key)
@@ -191,15 +215,31 @@ Logs warning to logger (if available) or stderr, then uses `development_jwt_secr
 
 ## Public Methods
 
+### `validate_jwt_secret!`
+
+Manually trigger JWT secret validation. This is the collision-free entry
+point — prefer it when both `hmac_secret_guard` and `jwt_secret_guard` are
+enabled.
+
+```ruby
+rodauth.validate_jwt_secret!
+# Raises error in production if the secret is missing, blank, or too short
+# Sets a fallback in development if the secret is missing
+```
+
 ### `validate_secrets!`
 
-Manually trigger secret validation.
+Backwards-compatible alias for `validate_jwt_secret!`.
 
 ```ruby
 rodauth.validate_secrets!
-# Raises error in production if secret missing
-# Sets fallback in development if secret missing
 ```
+
+> **Note:** `hmac_secret_guard` defines a `validate_secrets!` of its own. When
+> both guards are enabled this shared name resolves to only one of them, so use
+> the kind-specific `validate_jwt_secret!` / `validate_hmac_secret!` for an
+> unambiguous manual call. Boot-time validation does not rely on the alias —
+> each feature's `post_configure` validates its own secret independently.
 
 ### `production?`
 
@@ -518,7 +558,8 @@ Validation runs in `post_configure` hook:
 ```ruby
 def post_configure
   super
-  validate_secrets! if validate_secrets_on_configure?
+  Rodauth::SecretGuard.load_from_env!(self, :jwt)
+  validate_jwt_secret! if validate_secrets_on_configure?
 end
 ```
 
@@ -532,42 +573,38 @@ end
 
 ### Multiple Secrets
 
-Guard multiple secrets by calling the feature with different configurations:
+To guard both the JWT and HMAC secrets, enable both features. They share
+kind-keyed logic (`Rodauth::SecretGuard`), so each secret is validated
+independently at boot:
 
 ```ruby
 plugin :rodauth do
-  enable :jwt_secret_guard
-
-  # Validate jwt_secret
-  validate_secrets!
-
-  # Also validate jwt_secret if using JWT
-  if respond_to?(:jwt_secret)
-    unless jwt_secret
-      raise Rodauth::ConfigurationError, "JWT_SECRET must be set"
-    end
-  end
+  enable :jwt_secret_guard, :hmac_secret_guard
+  # Both JWT_SECRET and HMAC_SECRET are validated in post_configure
 end
 ```
 
 ### Custom Validation Logic
 
-> **Note:** `validate_secrets!` does not accept a block. To add custom validation logic, override the `validate_secrets!` method in your configuration.
+A minimum length is available out of the box via `minimum_secret_length`
+(production only). For anything beyond that, override the kind-specific
+`validate_jwt_secret!` method in your configuration.
+
+> **Note:** `validate_jwt_secret!` does not accept a block. Override the method
+> (not `validate_secrets!`, which is a shared alias) so it keeps working when
+> `hmac_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do
   enable :jwt_secret_guard
 
-  # Override validate_secrets! to add custom checks
-  def validate_secrets!
-    super # Call the original validation
+  minimum_secret_length 64  # enforced in production
+
+  # Override for additional checks
+  validate_jwt_secret! do
+    super() # Call the original validation
 
     secret = jwt_secret
-
-    # Custom length requirement
-    if secret && secret.length < 64
-      raise Rodauth::ConfigurationError, "JWT secret must be at least 64 characters"
-    end
 
     # Custom entropy check
     if secret && secret.chars.uniq.length < 16

--- a/docs/features/jwt-secret-guard.md
+++ b/docs/features/jwt-secret-guard.md
@@ -70,6 +70,17 @@ into source. It is therefore never publicly known and is unstable across
 restarts, so it can't be mistaken for a real, persistent secret. Set an explicit
 value only if you need JWTs to remain valid across restarts in development.
 
+> **Caution — multi-process and multi-host environments.** Because the default
+> fallback is generated per process and at random, it is **not** shared across
+> processes or hosts and changes on every restart. Previously-issued JWTs stop
+> validating after a restart, and won't validate across instances in a
+> load-balanced or multi-instance deployment (each process holds a different
+> fallback). This most often bites review apps, staging, CI, and load-balanced
+> development where `RACK_ENV` is not `production` yet more than one process is
+> involved. In those environments, set an explicit, stable
+> `development_jwt_secret_fallback` (or provide a real `JWT_SECRET`) rather than
+> relying on the random default.
+
 ```ruby
 development_jwt_secret_fallback 'my-custom-dev-secret-12345'
 ```
@@ -190,6 +201,14 @@ end
    - Production: Raise error if missing
    - Development: Warn and use fallback
 
+> **Note:** Secrets read from the environment variable are whitespace-trimmed —
+> leading and trailing whitespace is stripped, so `JWT_SECRET=" abc\n"` becomes
+> `"abc"` (this tolerates the trailing newlines common in `.env` files). A value
+> that is entirely whitespace is treated as **absent**, triggering the production
+> error or the development fallback. Secrets set directly via the `jwt_secret`
+> DSL are used verbatim, though the `minimum_secret_length` check measures their
+> length after stripping.
+
 ### Production Mode
 
 When `production?` returns true:
@@ -239,7 +258,10 @@ rodauth.validate_secrets!
 > both guards are enabled this shared name resolves to only one of them, so use
 > the kind-specific `validate_jwt_secret!` / `validate_hmac_secret!` for an
 > unambiguous manual call. Boot-time validation does not rely on the alias —
-> each feature's `post_configure` validates its own secret independently.
+> each feature's `post_configure` validates its own secret independently. The
+> same applies when **overriding** validation: with both guards enabled, override
+> the kind-specific `validate_jwt_secret!` (not `validate_secrets!`), or your
+> override will silently apply to only one of the two secrets.
 
 ### `production?`
 
@@ -583,6 +605,16 @@ plugin :rodauth do
   # Both JWT_SECRET and HMAC_SECRET are validated in post_configure
 end
 ```
+
+> **Shared vs. kind-specific settings.** When both guards are enabled,
+> `minimum_secret_length`, `production_env_check`, and
+> `validate_secrets_on_configure?` are each defined by both features under the
+> same name and are therefore **shared** — you set each once and it applies to
+> **both** secrets; you cannot give JWT and HMAC different values for these. The
+> env key, error messages, and fallback are kind-specific, so they can differ per
+> secret: `jwt_secret_env_key` vs `hmac_secret_env_key`,
+> `jwt_secret_missing_error` vs `hmac_secret_missing_error`, and
+> `development_jwt_secret_fallback` vs `development_hmac_secret_fallback`.
 
 ### Custom Validation Logic
 

--- a/docs/features/jwt-secret-guard.md
+++ b/docs/features/jwt-secret-guard.md
@@ -622,9 +622,11 @@ A minimum length is available out of the box via `minimum_secret_length`
 (production only). For anything beyond that, override the kind-specific
 `validate_jwt_secret!` method in your configuration.
 
-> **Note:** `validate_jwt_secret!` does not accept a block. Override the method
-> (not `validate_secrets!`, which is a shared alias) so it keeps working when
-> `hmac_secret_guard` is also enabled.
+> **Note:** `validate_jwt_secret!` does not take a block when *called* at
+> runtime. To customize validation, *override* the method in your configuration
+> (the block form shown below is the Rodauth config-DSL override, not a runtime
+> call). Override `validate_jwt_secret!` — not `validate_secrets!`, which is a
+> shared alias — so it keeps working when `hmac_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do

--- a/lib/rodauth/features/hmac_secret_guard.rb
+++ b/lib/rodauth/features/hmac_secret_guard.rb
@@ -2,6 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'securerandom'
+require_relative '../secret_guard'
+
 module Rodauth
   # Automatically sets hmac_secret based on HMAC_SECRET and validates it is properly
   # configured before the application starts. This helps prevent deployment
@@ -9,22 +12,33 @@ module Rodauth
   # particularly in production environments.
   #
   # By default, this feature checks during +post_configure+ that +hmac_secret+
-  # is set to a non-nil, non-empty value. In production mode, it raises a
+  # is set to a non-blank value. In production mode, it raises a
   # ConfigurationError if the secret is missing. In development mode, it logs
   # a warning and uses a fallback development secret.
+  #
+  # This feature and +jwt_secret_guard+ can be enabled together. Their shared
+  # logic lives in +Rodauth::SecretGuard+ and is keyed by secret kind, so each
+  # secret is validated independently at boot.
   #
   # @example Basic Configuration
   #   plugin :rodauth do
   #     enable :hmac_secret_guard
   #   end
   #
-  # @example Customizing Production Detection
+  # @example Customizing Production Detection (fail-safe)
   #   plugin :rodauth do
   #     enable :hmac_secret_guard
-  #     production_env_check proc { ENV['RACK_ENV'] == 'production' }
-  #     # Or use a boolean:
+  #     # Treat an unset RACK_ENV as production so a misconfigured deploy fails
+  #     # closed rather than silently using the development fallback secret:
+  #     production_env_check proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
+  #     # Or force it:
   #     # production_env_check true
   #   end
+  #
+  #   # The default already fails safe: an unset RACK_ENV is treated as
+  #   # production. Avoid `proc { ENV['RACK_ENV'] == 'production' }` — when the
+  #   # variable is unset that returns false and silently falls back to the
+  #   # insecure development secret in what is really a production deploy.
   #
   # @example Customizing Error Messages
   #   plugin :rodauth do
@@ -39,6 +53,16 @@ module Rodauth
   #     development_hmac_secret_fallback 'my-custom-dev-secret'
   #   end
   #
+  #   # The default fallback is a random per-process value (SecureRandom.hex),
+  #   # not a constant baked into source. Set an explicit value only if you need
+  #   # HMAC output to be stable across restarts in development.
+  #
+  # @example Enforcing a Minimum Secret Length (production only)
+  #   plugin :rodauth do
+  #     enable :hmac_secret_guard
+  #     minimum_secret_length 32  # reject short secrets in production; 0 disables (default)
+  #   end
+  #
   # @example Disabling Validation
   #   plugin :rodauth do
   #     enable :hmac_secret_guard
@@ -49,8 +73,10 @@ module Rodauth
     auth_value_method :hmac_secret_env_key, 'HMAC_SECRET'
     auth_value_method :production_env_check, proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
     auth_value_method :validate_secrets_on_configure?, true
-    auth_value_method :development_hmac_secret_fallback,
-                      'dev-only-insecure-example-hmac-secret-needs-to-be-changed-in-prod'
+    auth_value_method :minimum_secret_length, 0
+    # Random per-process fallback: never committed to source, and unstable across
+    # restarts so it can't be mistaken for a real, persistent secret.
+    auth_value_method :development_hmac_secret_fallback, SecureRandom.hex(32)
 
     translatable_method :hmac_secret_missing_error, 'HMAC_SECRET environment variable must be set in production'
     translatable_method :hmac_secret_dev_warning, '[rodauth] WARNING: Using default HMAC secret for development only'
@@ -58,62 +84,44 @@ module Rodauth
     def post_configure
       super
 
-      # Auto-set hmac_secret if not already set
-      if hmac_secret.nil? || (hmac_secret.respond_to?(:empty?) && hmac_secret.empty?)
-        env_value = ENV.delete(hmac_secret_env_key)
-        self.class.send(:define_method, :hmac_secret) { env_value } if env_value && !env_value.empty?
-      end
-
-      validate_secrets! if validate_secrets_on_configure?
+      Rodauth::SecretGuard.load_from_env!(self, :hmac)
+      validate_hmac_secret! if validate_secrets_on_configure?
     end
 
-    auth_methods :validate_secrets!, :production?
+    auth_methods :validate_secrets!, :validate_hmac_secret!, :production?
 
     # Check if we're running in production environment.
     #
     # @return [Boolean] true if running in production mode based on production_env_check
     def production?
-      case v = production_env_check
-      when Proc
-        instance_exec(&v)
-      else
-        !!v
-      end
+      Rodauth::SecretGuard.production?(self)
     end
 
-    # Validate that HMAC secret is properly configured.
-    # Raises ConfigurationError in production if secret is missing.
-    # In development, logs a warning and sets a fallback secret.
+    # Validate that the HMAC secret is properly configured. Raises
+    # ConfigurationError in production if the secret is missing, blank, or (when
+    # +minimum_secret_length+ is set) too short. In development it warns and
+    # installs a fallback secret.
     #
-    # @raise [Rodauth::ConfigurationError] if hmac_secret is missing in production
+    # This is the collision-free entry point: prefer it over +validate_secrets!+
+    # when both secret guards are enabled.
+    #
+    # @raise [Rodauth::ConfigurationError] if hmac_secret is unusable in production
+    # @return [void]
+    def validate_hmac_secret!
+      Rodauth::SecretGuard.validate!(self, :hmac)
+    end
+
+    # Backwards-compatible alias for +validate_hmac_secret!+.
+    #
+    # Note: +jwt_secret_guard+ defines a +validate_secrets!+ of its own, so when
+    # both guards are enabled this name resolves to only one of them. Boot-time
+    # validation does not rely on it (see +post_configure+); use
+    # +validate_hmac_secret!+ for an unambiguous manual call.
+    #
+    # @raise [Rodauth::ConfigurationError] if hmac_secret is unusable in production
     # @return [void]
     def validate_secrets!
-      # Get the current hmac_secret value (may be nil)
-      current_secret = hmac_secret
-
-      # Check if secret is missing or empty
-      return unless current_secret.nil? || (current_secret.respond_to?(:empty?) && current_secret.empty?)
-      raise Rodauth::ConfigurationError, hmac_secret_missing_error if production?
-
-      # In production, raise an error
-
-      # In development, warn and set a fallback
-      warn_dev_secret
-      self.class.send(:define_method, :hmac_secret) { development_hmac_secret_fallback }
-    end
-
-    private
-
-    # Warn about using development secret.
-    # Logs to logger if available, otherwise to stderr.
-    #
-    # @return [void]
-    def warn_dev_secret
-      if respond_to?(:logger) && logger
-        logger.warn(hmac_secret_dev_warning)
-      else
-        warn(hmac_secret_dev_warning)
-      end
+      validate_hmac_secret!
     end
   end
 end

--- a/lib/rodauth/features/jwt_secret_guard.rb
+++ b/lib/rodauth/features/jwt_secret_guard.rb
@@ -2,6 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'securerandom'
+require_relative '../secret_guard'
+
 module Rodauth
   # Automatically sets jwt_secret based on JWT_SECRET and validates it is properly
   # configured before the application starts. This helps prevent deployment
@@ -9,22 +12,33 @@ module Rodauth
   # particularly in production environments.
   #
   # By default, this feature checks during +post_configure+ that +jwt_secret+
-  # is set to a non-nil, non-empty value. In production mode, it raises a
+  # is set to a non-blank value. In production mode, it raises a
   # ConfigurationError if the secret is missing. In development mode, it logs
   # a warning and uses a fallback development secret.
+  #
+  # This feature and +hmac_secret_guard+ can be enabled together. Their shared
+  # logic lives in +Rodauth::SecretGuard+ and is keyed by secret kind, so each
+  # secret is validated independently at boot.
   #
   # @example Basic Configuration
   #   plugin :rodauth do
   #     enable :jwt_secret_guard
   #   end
   #
-  # @example Customizing Production Detection
+  # @example Customizing Production Detection (fail-safe)
   #   plugin :rodauth do
   #     enable :jwt_secret_guard
-  #     production_env_check proc { ENV['RACK_ENV'] == 'production' }
-  #     # Or use a boolean:
+  #     # Treat an unset RACK_ENV as production so a misconfigured deploy fails
+  #     # closed rather than silently using the development fallback secret:
+  #     production_env_check proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
+  #     # Or force it:
   #     # production_env_check true
   #   end
+  #
+  #   # The default already fails safe: an unset RACK_ENV is treated as
+  #   # production. Avoid `proc { ENV['RACK_ENV'] == 'production' }` — when the
+  #   # variable is unset that returns false and silently falls back to the
+  #   # insecure development secret in what is really a production deploy.
   #
   # @example Customizing Error Messages
   #   plugin :rodauth do
@@ -39,6 +53,16 @@ module Rodauth
   #     development_jwt_secret_fallback 'my-custom-dev-secret'
   #   end
   #
+  #   # The default fallback is a random per-process value (SecureRandom.hex),
+  #   # not a constant baked into source. Set an explicit value only if you need
+  #   # JWTs to remain valid across restarts in development.
+  #
+  # @example Enforcing a Minimum Secret Length (production only)
+  #   plugin :rodauth do
+  #     enable :jwt_secret_guard
+  #     minimum_secret_length 32  # reject short secrets in production; 0 disables (default)
+  #   end
+  #
   # @example Disabling Validation
   #   plugin :rodauth do
   #     enable :jwt_secret_guard
@@ -49,8 +73,10 @@ module Rodauth
     auth_value_method :jwt_secret_env_key, 'JWT_SECRET'
     auth_value_method :production_env_check, proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
     auth_value_method :validate_secrets_on_configure?, true
-    auth_value_method :development_jwt_secret_fallback,
-                      'dev-only-insecure-example-jwt-secret-needs-to-be-changed-in-prod'
+    auth_value_method :minimum_secret_length, 0
+    # Random per-process fallback: never committed to source, and unstable across
+    # restarts so it can't be mistaken for a real, persistent secret.
+    auth_value_method :development_jwt_secret_fallback, SecureRandom.hex(32)
 
     # Make jwt_secret configurable (if not already provided by jwt feature)
     auth_value_method :jwt_secret, nil
@@ -61,60 +87,44 @@ module Rodauth
     def post_configure
       super
 
-      # Auto-set jwt_secret if not already set
-      if jwt_secret.nil? || (jwt_secret.respond_to?(:empty?) && jwt_secret.empty?)
-        env_value = ENV.delete(jwt_secret_env_key)
-        self.class.send(:define_method, :jwt_secret) { env_value } if env_value && !env_value.empty?
-      end
-
-      validate_secrets! if validate_secrets_on_configure?
+      Rodauth::SecretGuard.load_from_env!(self, :jwt)
+      validate_jwt_secret! if validate_secrets_on_configure?
     end
 
-    auth_methods :validate_secrets!, :production?
+    auth_methods :validate_secrets!, :validate_jwt_secret!, :production?
 
     # Check if we're running in production environment.
     #
     # @return [Boolean] true if running in production mode based on production_env_check
     def production?
-      case v = production_env_check
-      when Proc
-        instance_exec(&v)
-      else
-        !!v
-      end
+      Rodauth::SecretGuard.production?(self)
     end
 
-    # Validate that JWT secret is properly configured.
-    # Raises ConfigurationError in production if secret is missing.
-    # In development, logs a warning and sets a fallback secret.
+    # Validate that the JWT secret is properly configured. Raises
+    # ConfigurationError in production if the secret is missing, blank, or (when
+    # +minimum_secret_length+ is set) too short. In development it warns and
+    # installs a fallback secret.
     #
-    # @raise [Rodauth::ConfigurationError] if jwt_secret is missing in production
+    # This is the collision-free entry point: prefer it over +validate_secrets!+
+    # when both secret guards are enabled.
+    #
+    # @raise [Rodauth::ConfigurationError] if jwt_secret is unusable in production
+    # @return [void]
+    def validate_jwt_secret!
+      Rodauth::SecretGuard.validate!(self, :jwt)
+    end
+
+    # Backwards-compatible alias for +validate_jwt_secret!+.
+    #
+    # Note: +hmac_secret_guard+ defines a +validate_secrets!+ of its own, so when
+    # both guards are enabled this name resolves to only one of them. Boot-time
+    # validation does not rely on it (see +post_configure+); use
+    # +validate_jwt_secret!+ for an unambiguous manual call.
+    #
+    # @raise [Rodauth::ConfigurationError] if jwt_secret is unusable in production
     # @return [void]
     def validate_secrets!
-      # Get the current jwt_secret value (may be nil)
-      current_secret = jwt_secret
-
-      # Return early if secret is present
-      return unless current_secret.nil? || (current_secret.respond_to?(:empty?) && current_secret.empty?)
-      raise Rodauth::ConfigurationError, jwt_secret_missing_error if production?
-
-      # In development, warn and set a fallback
-      warn_dev_secret
-      self.class.send(:define_method, :jwt_secret) { development_jwt_secret_fallback }
-    end
-
-    private
-
-    # Warn about using development secret.
-    # Logs to logger if available, otherwise to stderr.
-    #
-    # @return [void]
-    def warn_dev_secret
-      if respond_to?(:logger) && logger
-        logger.warn(jwt_secret_dev_warning)
-      else
-        warn(jwt_secret_dev_warning)
-      end
+      validate_jwt_secret!
     end
   end
 end

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -222,9 +222,19 @@ module Rodauth
 
     # Check if a table exists in the database
     #
-    # Temporarily suppresses Sequel's logger to avoid confusing error logs
-    # when checking non-existent tables (Sequel logs SQLite exceptions before
-    # catching them internally).
+    # Uses the database's table list (db.tables) rather than probing each table
+    # with a SELECT. Sequel's db.table_exists? probe logs the "no such table"
+    # exception before catching it internally, which the previous implementation
+    # worked around by clearing and restoring the shared db.loggers array around
+    # the call. That mutation of shared connection state was not thread-safe:
+    # a concurrent query (e.g. when table_status/column_status are called at
+    # runtime) could execute while logging was disabled. Listing tables avoids
+    # the failed probe entirely, so no logger suppression — and no shared-state
+    # mutation — is needed.
+    #
+    # NOTE: On a genuine error we still fail open (assume the table exists) to
+    # preserve current behavior; switching this to fail closed is tracked in the
+    # table_guard hardening follow-up.
     #
     # @param table_name [String, Symbol] Table name
     # @return [Boolean] True if table exists
@@ -232,23 +242,10 @@ module Rodauth
       return true if table_guard_skip_tables.include?(table_name.to_sym) ||
                      table_guard_skip_tables.include?(table_name.to_s)
 
-      # Temporarily suppress Sequel's logger to prevent confusing error logs
-      # during table existence checks. Sequel's table_exists? implementation
-      # attempts a SELECT query and logs the exception if table doesn't exist,
-      # even though it catches the error internally.
-      original_logger = db.loggers.dup
-      db.loggers.clear
-
-      db.table_exists?(table_name)
+      db.tables.map(&:to_sym).include?(table_name.to_sym)
     rescue StandardError => e
       rodauth_warn("[table_guard] Unable to check table existence for #{table_name}: #{e.message}")
-      true # Assume exists to avoid false positives
-    ensure
-      # Restore original loggers
-      if original_logger
-        db.loggers.clear
-        original_logger.each { |logger| db.loggers << logger }
-      end
+      true # Assume exists to avoid false positives (see hardening follow-up)
     end
 
     # List all required table names (sorted)

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -198,9 +198,14 @@ module Rodauth
     def missing_tables
       result = []
 
+      # Fetch the set of existing table names ONCE for this pass and reuse it
+      # across every table check, instead of running a catalog query per table
+      # (N+1). See #table_exists? for why the set is not cached on the instance.
+      existing = existing_table_names
+
       table_configuration.each do |method, info|
         table_name = info[:name]
-        next if table_exists?(table_name)
+        next if table_exists?(table_name, existing)
 
         result << {
           method: method,
@@ -222,27 +227,58 @@ module Rodauth
 
     # Check if a table exists in the database
     #
-    # Uses the database's table list (db.tables) rather than probing each table
-    # with a SELECT. Sequel's db.table_exists? probe logs the "no such table"
-    # exception before catching it internally, which the previous implementation
-    # worked around by clearing and restoring the shared db.loggers array around
-    # the call. That mutation of shared connection state was not thread-safe:
-    # a concurrent query (e.g. when table_status/column_status are called at
-    # runtime) could execute while logging was disabled. Listing tables avoids
-    # the failed probe entirely, so no logger suppression — and no shared-state
-    # mutation — is needed.
+    # For the common case (an unqualified base table in the default schema) this
+    # matches against the database's table/view list rather than probing each
+    # table with a SELECT. Sequel's db.table_exists? probe logs the "no such
+    # table" exception before catching it internally, which an earlier
+    # implementation worked around by clearing and restoring the shared
+    # db.loggers array around the call. That mutation of shared connection state
+    # was not thread-safe: a concurrent query (e.g. when table_status/
+    # column_status are called at runtime) could execute while logging was
+    # disabled. Matching against the listed names avoids the failed probe
+    # entirely, so no logger suppression — and no shared-state mutation — is
+    # needed. Views are included (via db.views when the adapter supports it)
+    # because a Rodauth table can legitimately be backed by a view, which
+    # db.tables alone omits on most adapters.
+    #
+    # Schema-qualified names (a Symbol like :auth__accounts, a
+    # Sequel::SQL::QualifiedIdentifier, or a Sequel.qualify(...) result) are NOT
+    # reflected in db.tables (which returns unqualified names from the current
+    # search_path), so they take a separate, schema-aware path: we probe with
+    # db.table_exists?. That probe can emit Sequel's error-log noise, but it is
+    # confined to this rare qualified path and never fires for the common
+    # unqualified case that #116 was about.
+    #
+    # The optional existing_tables argument lets looping callers
+    # (missing_tables, table_status) build the existing-name Set ONCE per
+    # introspection pass and reuse it, avoiding N catalog queries. When omitted
+    # (the single-name public call) a fresh set is fetched — the set is
+    # deliberately NOT cached on the instance so runtime introspection does not
+    # go stale if tables are created after boot.
     #
     # NOTE: On a genuine error we still fail open (assume the table exists) to
     # preserve current behavior; switching this to fail closed is tracked in the
     # table_guard hardening follow-up (issue #116).
     #
-    # @param table_name [String, Symbol] Table name
+    # @param table_name [String, Symbol, Sequel::SQL::QualifiedIdentifier] Table name
+    # @param existing_tables [Set<Symbol>, nil] Pre-fetched existing table names
     # @return [Boolean] True if table exists
-    def table_exists?(table_name)
-      return true if table_guard_skip_tables.include?(table_name.to_sym) ||
-                     table_guard_skip_tables.include?(table_name.to_s)
+    def table_exists?(table_name, existing_tables = nil)
+      # Symbol/String names may be skipped by configuration. A
+      # QualifiedIdentifier does not respond to to_sym, so guard the lookup.
+      if table_name.respond_to?(:to_sym) &&
+         (table_guard_skip_tables.include?(table_name.to_sym) ||
+          table_guard_skip_tables.include?(table_name.to_s))
+        return true
+      end
 
-      db.tables.map(&:to_sym).include?(table_name.to_sym)
+      # Qualified names live outside the current search_path's unqualified
+      # listing, so probe them directly (schema-aware) rather than matching the
+      # Set. Rare path — the log noise this can produce does not hit boot.
+      return db.table_exists?(table_name) if qualified_table_name?(table_name)
+
+      existing_tables ||= existing_table_names
+      existing_tables.include?(table_name.to_sym)
     rescue StandardError => e
       rodauth_warn("[table_guard] Unable to check table existence for #{table_name}: #{e.message}")
       true # Assume exists to avoid false positives (see hardening follow-up #116)
@@ -259,12 +295,15 @@ module Rodauth
     #
     # @return [Array<Hash>] Status information for each table
     def table_status
+      # Build the existing-name set once and reuse it (see missing_tables).
+      existing = existing_table_names
+
       table_configuration.map do |method, info|
         {
           method: method,
           table: info[:name],
           feature: info[:feature],
-          exists: table_exists?(info[:name])
+          exists: table_exists?(info[:name], existing)
         }
       end
     end
@@ -410,6 +449,40 @@ module Rodauth
     end
 
     private
+
+    # Build the set of unqualified table names that currently exist, including
+    # views (which db.tables omits on most adapters but which can legitimately
+    # back a Rodauth table).
+    #
+    # Fetched fresh on each call — never memoized on the instance — so runtime
+    # introspection reflects tables created after boot. Looping callers pass the
+    # result into #table_exists? to fetch it only once per pass (see #116 / N+1).
+    #
+    # @return [Set<Symbol>] Existing base-table and view names
+    def existing_table_names
+      names = db.tables.map(&:to_sym)
+      names.concat(db.views.map(&:to_sym)) if db.respond_to?(:views)
+      names.to_set
+    end
+
+    # Determine whether a table identifier is schema-qualified.
+    #
+    # Qualified identifiers are not present in db.tables (which lists unqualified
+    # names from the current search_path), so #table_exists? routes them to a
+    # schema-aware probe instead of the Set match.
+    #
+    # Recognizes Sequel's qualified forms: a QualifiedIdentifier (from
+    # Sequel.qualify) and the implicit-qualification Symbol form :schema__table.
+    # A String with underscores is a literal name, not a qualification.
+    #
+    # @param table_name [Object] Table identifier
+    # @return [Boolean] True if schema-qualified
+    def qualified_table_name?(table_name)
+      return true if defined?(Sequel::SQL::QualifiedIdentifier) &&
+                     table_name.is_a?(Sequel::SQL::QualifiedIdentifier)
+
+      table_name.is_a?(Symbol) && table_name.to_s.include?('__')
+    end
 
     # Resolve table_guard_mode to its symbol value, or nil when it is a
     # block/Proc handler.

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -234,7 +234,7 @@ module Rodauth
     #
     # NOTE: On a genuine error we still fail open (assume the table exists) to
     # preserve current behavior; switching this to fail closed is tracked in the
-    # table_guard hardening follow-up.
+    # table_guard hardening follow-up (issue #116).
     #
     # @param table_name [String, Symbol] Table name
     # @return [Boolean] True if table exists
@@ -245,7 +245,7 @@ module Rodauth
       db.tables.map(&:to_sym).include?(table_name.to_sym)
     rescue StandardError => e
       rodauth_warn("[table_guard] Unable to check table existence for #{table_name}: #{e.message}")
-      true # Assume exists to avoid false positives (see hardening follow-up)
+      true # Assume exists to avoid false positives (see hardening follow-up #116)
     end
 
     # List all required table names (sorted)

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -414,6 +414,23 @@ module Rodauth
 
     private
 
+    # Resolve table_guard_mode to its symbol value, or nil when it is a
+    # block/Proc handler.
+    #
+    # A block handler (arity > 0) cannot be evaluated without arguments, and a
+    # 0-arity Proc is a custom handler rather than a mode symbol; in both cases
+    # there is no symbol to compare against, so we return nil. This lets callers
+    # do `%i[raise halt exit].include?(table_guard_mode_symbol)` safely instead
+    # of invoking table_guard_mode with the wrong arity.
+    #
+    # @return [Symbol, nil] the configured mode symbol, or nil for block/Proc handlers
+    def table_guard_mode_symbol
+      return nil if method(:table_guard_mode).arity > 0
+
+      value = table_guard_mode
+      value.is_a?(Proc) ? nil : value
+    end
+
     # Handle column validation based on mode setting
     #
     # @param missing_cols [Array<Hash>] Missing column information
@@ -657,7 +674,10 @@ module Rodauth
     rescue StandardError => e
       rodauth_error("[table_guard] Sequel generation failed: #{e.class} - #{e.message}")
       rodauth_error("  Location: #{e.backtrace.first}")
-      raise if %i[raise halt exit].include?(table_guard_mode)
+      # Use the resolved symbol mode: calling table_guard_mode directly would
+      # raise ArgumentError here when the user configured a block handler
+      # (arity > 0), masking the real error `e` we are trying to surface.
+      raise if %i[raise halt exit].include?(table_guard_mode_symbol)
     end
 
     # Check if the database supports CASCADE on DELETE

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -462,7 +462,12 @@ module Rodauth
     def existing_table_names
       names = db.tables.map(&:to_sym)
       names.concat(db.views.map(&:to_sym)) if db.respond_to?(:views)
-      names.to_set
+      # Set.new (not names.to_set): referencing the Set constant triggers its
+      # autoload on Ruby >= 3.2 (the gem's floor), whereas Enumerable#to_set is
+      # only defined once 'set' is already loaded. Using to_set here would rely
+      # on a dependency having required 'set' first and could otherwise raise
+      # NoMethodError. This also keeps Lint/RedundantRequireStatement satisfied.
+      Set.new(names)
     end
 
     # Determine whether a table identifier is schema-qualified.

--- a/lib/rodauth/secret_guard.rb
+++ b/lib/rodauth/secret_guard.rb
@@ -97,8 +97,14 @@ module Rodauth
       return unless rodauth.production?
       return if value.to_s.strip.length >= minimum
 
+      # Name the secret generically and cite both configuration avenues: the
+      # value may have come from the env var OR from the #{kind}_secret DSL
+      # method, so blaming the env key alone would mislead when a short secret
+      # was configured directly.
+      key = rodauth.send(:"#{kind}_secret_env_key")
       raise Rodauth::ConfigurationError,
-            "#{rodauth.send(:"#{kind}_secret_env_key")} must be at least #{minimum} characters in production"
+            "#{kind.to_s.upcase} secret must be at least #{minimum} characters in production " \
+            "(set via #{key} or #{kind}_secret)"
     end
 
     # @return [Boolean] true when the value is nil, empty, or whitespace-only

--- a/lib/rodauth/secret_guard.rb
+++ b/lib/rodauth/secret_guard.rb
@@ -1,0 +1,131 @@
+# lib/rodauth/secret_guard.rb
+#
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Rodauth
+  # Shared, secret-kind-parameterized logic behind the +hmac_secret_guard+ and
+  # +jwt_secret_guard+ features.
+  #
+  # The two guard features are nearly identical; the only thing that differs is
+  # the "kind" of secret they manage (+:hmac+ or +:jwt+) and the names of the
+  # configuration methods that carry that kind as a prefix
+  # (+hmac_secret_env_key+ vs +jwt_secret_env_key+, and so on).
+  #
+  # Keeping this logic in one place — and taking +kind+ as an explicit argument
+  # rather than baking it into method names — is what lets both features be
+  # enabled at the same time. Each feature's +post_configure+ calls into these
+  # helpers with its own +kind+, so both secrets are validated at boot. When the
+  # per-feature methods shared a name (the previous design), enabling both
+  # guards meant one definition shadowed the other and only a single secret was
+  # ever validated.
+  #
+  # These are plain module functions that take the Rodauth instance explicitly
+  # (rather than being mixed in) so there is no method-name surface to collide
+  # in the first place.
+  module SecretGuard
+    module_function
+
+    # Auto-populate +<kind>_secret+ from its environment variable when it has
+    # not been configured explicitly.
+    #
+    # The variable is read with +ENV.delete+ so the raw secret does not linger
+    # in the process environment after boot. A blank (nil/empty/whitespace-only)
+    # value is treated as absent and leaves the secret unset for +validate!+ to
+    # handle.
+    #
+    # @param rodauth [Rodauth::Auth] the Rodauth instance being configured
+    # @param kind [Symbol] the secret kind (+:hmac+ or +:jwt+)
+    # @return [void]
+    def load_from_env!(rodauth, kind)
+      return unless blank?(rodauth.send(:"#{kind}_secret"))
+
+      raw = ENV.delete(rodauth.send(:"#{kind}_secret_env_key"))
+      value = raw&.strip
+      return if value.nil? || value.empty?
+
+      define_secret(rodauth, kind, value)
+    end
+
+    # Validate that +<kind>_secret+ is usable.
+    #
+    # In production a missing (nil/empty/whitespace-only) or too-short secret
+    # raises +Rodauth::ConfigurationError+ — the guard fails closed. Outside
+    # production a missing secret logs a warning and falls back to the
+    # (ephemeral, per-process) development fallback.
+    #
+    # @param rodauth [Rodauth::Auth] the Rodauth instance being configured
+    # @param kind [Symbol] the secret kind (+:hmac+ or +:jwt+)
+    # @raise [Rodauth::ConfigurationError] when the secret is unusable in production
+    # @return [void]
+    def validate!(rodauth, kind)
+      current = rodauth.send(:"#{kind}_secret")
+
+      unless blank?(current)
+        enforce_minimum_length!(rodauth, kind, current)
+        return
+      end
+
+      raise Rodauth::ConfigurationError, rodauth.send(:"#{kind}_secret_missing_error") if rodauth.production?
+
+      warn(rodauth, rodauth.send(:"#{kind}_secret_dev_warning"))
+      define_secret(rodauth, kind, rodauth.send(:"development_#{kind}_secret_fallback"))
+    end
+
+    # Resolve the configured production check into a boolean.
+    #
+    # A Proc is evaluated in the Rodauth instance context (so it can read config
+    # methods); anything else is coerced with +!!+.
+    #
+    # @param rodauth [Rodauth::Auth] the Rodauth instance being configured
+    # @return [Boolean]
+    def production?(rodauth)
+      check = rodauth.send(:production_env_check)
+      check.is_a?(Proc) ? rodauth.instance_exec(&check) : !!check
+    end
+
+    # Enforce +minimum_secret_length+ when it is configured (> 0).
+    #
+    # Only applied in production so development fallbacks and short test secrets
+    # are unaffected. Disabled by default.
+    #
+    # @return [void]
+    def enforce_minimum_length!(rodauth, kind, value)
+      minimum = rodauth.send(:minimum_secret_length).to_i
+      return if minimum <= 0
+      return unless rodauth.production?
+      return if value.to_s.strip.length >= minimum
+
+      raise Rodauth::ConfigurationError,
+            "#{rodauth.send(:"#{kind}_secret_env_key")} must be at least #{minimum} characters in production"
+    end
+
+    # @return [Boolean] true when the value is nil, empty, or whitespace-only
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+
+    # Redefine +<kind>_secret+ on the Rodauth subclass to return +value+.
+    #
+    # This mirrors how Rodauth features memoize resolved config: the auth class
+    # is per-configuration and this runs once, single-threaded, at boot.
+    #
+    # @return [void]
+    def define_secret(rodauth, kind, value)
+      rodauth.class.send(:define_method, :"#{kind}_secret") { value }
+    end
+
+    # Emit a development warning via the Rodauth logger when present, otherwise
+    # to stderr.
+    #
+    # @return [void]
+    def warn(rodauth, message)
+      if rodauth.respond_to?(:logger) && rodauth.logger
+        rodauth.logger.warn(message)
+      else
+        Kernel.warn(message)
+      end
+    end
+  end
+end

--- a/spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb
+++ b/spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'HmacSecretGuard' do
   end
 
   describe 'development mode fallback' do
-    it 'warns and uses fallback when secret missing' do
+    it 'warns and uses a random fallback when secret missing' do
       output = capture_warnings do
         app = create_roda_app do
           enable :hmac_secret_guard
@@ -107,7 +107,12 @@ RSpec.describe 'HmacSecretGuard' do
 
         expect(app).not_to be_nil
         rodauth_instance = app.rodauth.allocate
-        expect(rodauth_instance.hmac_secret).to eq('dev-only-insecure-example-hmac-secret-needs-to-be-changed-in-prod')
+        secret = rodauth_instance.hmac_secret
+        expect(secret).to be_a(String)
+        expect(secret).not_to be_empty
+        # No longer a constant baked into source
+        expect(secret).not_to eq('dev-only-insecure-example-hmac-secret-needs-to-be-changed-in-prod')
+        expect(secret.length).to be >= 32
       end
 
       expect(output).to include('WARNING')
@@ -333,6 +338,89 @@ RSpec.describe 'HmacSecretGuard' do
       end.to raise_error(Rodauth::ConfigurationError)
 
       ENV.delete('HMAC_SECRET')
+    end
+
+    it 'treats a whitespace-only secret as missing in production' do
+      expect do
+        create_roda_app do
+          enable :hmac_secret_guard
+          production_env_check true
+          hmac_secret "   \t\n"
+        end
+      end.to raise_error(Rodauth::ConfigurationError)
+    end
+
+    it 'treats a whitespace-only environment variable as missing' do
+      ENV['HMAC_SECRET'] = "   \n"
+
+      expect do
+        create_roda_app do
+          enable :hmac_secret_guard
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError)
+
+      ENV.delete('HMAC_SECRET')
+    end
+  end
+
+  describe 'minimum_secret_length' do
+    it 'is disabled by default (short secret accepted)' do
+      app = create_roda_app do
+        enable :hmac_secret_guard
+        production_env_check true
+        hmac_secret 'short'
+      end
+
+      expect(app).not_to be_nil
+    end
+
+    it 'rejects a too-short secret in production when configured' do
+      expect do
+        create_roda_app do
+          enable :hmac_secret_guard
+          production_env_check true
+          minimum_secret_length 32
+          hmac_secret 'too-short-secret'
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /at least 32/)
+    end
+
+    it 'accepts a sufficiently long secret when configured' do
+      app = create_roda_app do
+        enable :hmac_secret_guard
+        production_env_check true
+        minimum_secret_length 16
+        hmac_secret 'a-secret-that-is-long-enough'
+      end
+
+      expect(app).not_to be_nil
+    end
+
+    it 'does not enforce the minimum outside production' do
+      app = create_roda_app do
+        enable :hmac_secret_guard
+        production_env_check false
+        minimum_secret_length 64
+        hmac_secret 'short-dev-secret'
+      end
+
+      expect(app).not_to be_nil
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.hmac_secret).to eq('short-dev-secret')
+    end
+  end
+
+  describe 'validate_hmac_secret!' do
+    it 'provides a collision-free validation entry point' do
+      app = create_roda_app do
+        enable :hmac_secret_guard
+        validate_secrets_on_configure? false
+        production_env_check true
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect { rodauth_instance.validate_hmac_secret! }.to raise_error(Rodauth::ConfigurationError)
     end
   end
 end

--- a/spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb
+++ b/spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'JwtSecretGuard' do
   end
 
   describe 'development mode fallback' do
-    it 'warns and uses fallback when secret missing' do
+    it 'warns and uses a random fallback when secret missing' do
       output = capture_warnings do
         app = create_roda_app do
           enable :jwt_secret_guard
@@ -106,7 +106,12 @@ RSpec.describe 'JwtSecretGuard' do
 
         expect(app).not_to be_nil
         rodauth_instance = app.rodauth.allocate
-        expect(rodauth_instance.jwt_secret).to eq('dev-only-insecure-example-jwt-secret-needs-to-be-changed-in-prod')
+        secret = rodauth_instance.jwt_secret
+        expect(secret).to be_a(String)
+        expect(secret).not_to be_empty
+        # No longer a constant baked into source
+        expect(secret).not_to eq('dev-only-insecure-example-jwt-secret-needs-to-be-changed-in-prod')
+        expect(secret.length).to be >= 32
       end
 
       expect(output).to include('WARNING')
@@ -332,6 +337,89 @@ RSpec.describe 'JwtSecretGuard' do
       end.to raise_error(Rodauth::ConfigurationError)
 
       ENV.delete('JWT_SECRET')
+    end
+
+    it 'treats a whitespace-only secret as missing in production' do
+      expect do
+        create_roda_app do
+          enable :jwt_secret_guard
+          production_env_check true
+          jwt_secret "   \t\n"
+        end
+      end.to raise_error(Rodauth::ConfigurationError)
+    end
+
+    it 'treats a whitespace-only environment variable as missing' do
+      ENV['JWT_SECRET'] = "   \n"
+
+      expect do
+        create_roda_app do
+          enable :jwt_secret_guard
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError)
+
+      ENV.delete('JWT_SECRET')
+    end
+  end
+
+  describe 'minimum_secret_length' do
+    it 'is disabled by default (short secret accepted)' do
+      app = create_roda_app do
+        enable :jwt_secret_guard
+        production_env_check true
+        jwt_secret 'short'
+      end
+
+      expect(app).not_to be_nil
+    end
+
+    it 'rejects a too-short secret in production when configured' do
+      expect do
+        create_roda_app do
+          enable :jwt_secret_guard
+          production_env_check true
+          minimum_secret_length 32
+          jwt_secret 'too-short-secret'
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /at least 32/)
+    end
+
+    it 'accepts a sufficiently long secret when configured' do
+      app = create_roda_app do
+        enable :jwt_secret_guard
+        production_env_check true
+        minimum_secret_length 16
+        jwt_secret 'a-secret-that-is-long-enough'
+      end
+
+      expect(app).not_to be_nil
+    end
+
+    it 'does not enforce the minimum outside production' do
+      app = create_roda_app do
+        enable :jwt_secret_guard
+        production_env_check false
+        minimum_secret_length 64
+        jwt_secret 'short-dev-secret'
+      end
+
+      expect(app).not_to be_nil
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.jwt_secret).to eq('short-dev-secret')
+    end
+  end
+
+  describe 'validate_jwt_secret!' do
+    it 'provides a collision-free validation entry point' do
+      app = create_roda_app do
+        enable :jwt_secret_guard
+        validate_secrets_on_configure? false
+        production_env_check true
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect { rodauth_instance.validate_jwt_secret! }.to raise_error(Rodauth::ConfigurationError)
     end
   end
 end

--- a/spec/rodauth/features/secret_guard_combined_spec.rb
+++ b/spec/rodauth/features/secret_guard_combined_spec.rb
@@ -1,0 +1,118 @@
+# spec/rodauth/features/secret_guard_combined_spec.rb
+#
+# frozen_string_literal: true
+
+# Regression coverage for the method-name collision between hmac_secret_guard
+# and jwt_secret_guard. Previously both features defined identically named
+# methods (validate_secrets!, production?, warn_dev_secret); enabling both meant
+# one definition shadowed the other and only a single secret was validated at
+# boot. The shared Rodauth::SecretGuard logic is keyed by secret kind so each
+# feature validates its own secret independently.
+
+require 'spec_helper'
+require 'sequel'
+require 'rodauth'
+require 'roda'
+
+RSpec.describe 'HmacSecretGuard + JwtSecretGuard enabled together' do
+  let(:db) { Sequel.sqlite }
+
+  after do
+    db.disconnect if db
+  end
+
+  def create_roda_app(&rodauth_block)
+    test_db = db
+
+    Class.new(Roda) do
+      plugin :rodauth do
+        db test_db
+        instance_eval(&rodauth_block) if rodauth_block
+      end
+
+      route do |r|
+        r.rodauth
+      end
+    end
+  end
+
+  def capture_warnings
+    old_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = old_stderr
+  end
+
+  it 'validates the JWT secret even when the HMAC secret is present' do
+    expect do
+      create_roda_app do
+        enable :hmac_secret_guard, :jwt_secret_guard
+        production_env_check true
+        hmac_secret 'present-hmac-secret-value'
+        # jwt_secret intentionally left unset
+      end
+    end.to raise_error(Rodauth::ConfigurationError, /JWT/)
+  end
+
+  it 'validates the HMAC secret even when the JWT secret is present' do
+    expect do
+      create_roda_app do
+        enable :hmac_secret_guard, :jwt_secret_guard
+        production_env_check true
+        jwt_secret 'present-jwt-secret-value'
+        # hmac_secret intentionally left unset
+      end
+    end.to raise_error(Rodauth::ConfigurationError, /HMAC/)
+  end
+
+  it 'validation order does not matter (jwt enabled first)' do
+    expect do
+      create_roda_app do
+        enable :jwt_secret_guard, :hmac_secret_guard
+        production_env_check true
+        jwt_secret 'present-jwt-secret-value'
+        # hmac_secret intentionally left unset
+      end
+    end.to raise_error(Rodauth::ConfigurationError, /HMAC/)
+  end
+
+  it 'succeeds when both secrets are present in production' do
+    app = create_roda_app do
+      enable :hmac_secret_guard, :jwt_secret_guard
+      production_env_check true
+      hmac_secret 'present-hmac-secret-value'
+      jwt_secret 'present-jwt-secret-value'
+    end
+
+    expect(app).not_to be_nil
+    rodauth_instance = app.rodauth.allocate
+    expect(rodauth_instance.hmac_secret).to eq('present-hmac-secret-value')
+    expect(rodauth_instance.jwt_secret).to eq('present-jwt-secret-value')
+  end
+
+  it 'installs independent development fallbacks for both secrets' do
+    app = nil
+    output = capture_warnings do
+      app = create_roda_app do
+        enable :hmac_secret_guard, :jwt_secret_guard
+        production_env_check false
+      end
+    end
+
+    rodauth_instance = app.rodauth.allocate
+    hmac = rodauth_instance.hmac_secret
+    jwt = rodauth_instance.jwt_secret
+
+    expect(hmac).to be_a(String)
+    expect(jwt).to be_a(String)
+    expect(hmac).not_to be_empty
+    expect(jwt).not_to be_empty
+    # Distinct per-kind fallbacks, not a single shared value
+    expect(hmac).not_to eq(jwt)
+
+    expect(output).to include('HMAC secret')
+    expect(output).to include('JWT secret')
+  end
+end

--- a/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
+++ b/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
@@ -201,4 +201,52 @@ RSpec.describe 'TableGuard Simple' do
 
     expect(app).not_to be_nil
   end
+
+  describe 'sequel generation error handling with a block mode' do
+    # Regression: the rescue in handle_sequel_generation used to evaluate
+    # table_guard_mode directly, which raises ArgumentError when the user
+    # configured a block handler (arity > 0) — masking the real error.
+
+    it 'resolves a block mode to nil instead of invoking it with no args' do
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode { |_missing| :continue }
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.send(:table_guard_mode_symbol)).to be_nil
+    end
+
+    it 'resolves a symbol mode to its symbol' do
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent # avoids raising at boot on the empty test db
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.send(:table_guard_mode_symbol)).to eq(:silent)
+    end
+
+    it 'does not crash the error handler when generation fails under a block mode' do
+      require 'tempfile'
+      tmp = Tempfile.new('table_guard_bad_path')
+      # A path whose ancestor is a regular file makes FileUtils.mkdir_p raise,
+      # forcing the rescue in handle_sequel_generation to run.
+      bad_path = "#{tmp.path}/subdir"
+
+      capture_warnings do
+        expect do
+          create_roda_app do
+            enable :table_guard
+            table_guard_mode { |_missing| :continue } # block handler, arity 1
+            table_guard_sequel_mode :migration
+            table_guard_migration_path bad_path
+          end
+        end.not_to raise_error # with the bug: ArgumentError (wrong number of arguments)
+      end
+    ensure
+      tmp&.close
+      tmp&.unlink
+    end
+  end
 end

--- a/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
+++ b/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
@@ -249,4 +249,55 @@ RSpec.describe 'TableGuard Simple' do
       tmp&.unlink
     end
   end
+
+  describe '#table_exists?' do
+    # These exercise the db.tables-based existence check (which replaced the
+    # SELECT-probe + shared db.loggers mutation).
+
+    it 'returns true for an existing table' do
+      create_accounts_table(db)
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.table_exists?(:accounts)).to be true
+    end
+
+    it 'returns false for a missing table' do
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.table_exists?(:does_not_exist)).to be false
+    end
+
+    it 'returns true for a skipped table even when it is missing' do
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+        table_guard_skip_tables [:does_not_exist]
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.table_exists?(:does_not_exist)).to be true
+    end
+
+    it 'does not mutate db.loggers while checking' do
+      require 'logger'
+      logger = Logger.new(StringIO.new)
+      db.loggers << logger
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      rodauth_instance.table_exists?(:accounts)
+      expect(db.loggers).to eq([logger])
+    end
+  end
 end

--- a/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
+++ b/spec/rodauth/features/table_guard/table_guard_simple_spec.rb
@@ -299,5 +299,66 @@ RSpec.describe 'TableGuard Simple' do
       rodauth_instance.table_exists?(:accounts)
       expect(db.loggers).to eq([logger])
     end
+
+    it 'returns true for a view-backed name' do
+      # A Rodauth table can be backed by a database view. db.tables omits views
+      # on most adapters, so table_exists? must also consult db.views.
+      create_accounts_table(db)
+      db.create_view(:accounts_view, db[:accounts])
+
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      expect(rodauth_instance.table_exists?(:accounts_view)).to be true
+    end
+
+    it 'returns true for a schema-qualified name of an existing table' do
+      # A schema-qualified identifier is not present in db.tables (which lists
+      # unqualified names from the current search_path), so it takes the
+      # schema-aware probe path. SQLite's default schema is "main", so
+      # Sequel.qualify(:main, :accounts) resolves to the existing accounts table.
+      create_accounts_table(db)
+
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      qualified = Sequel.qualify(:main, :accounts)
+      expect(rodauth_instance.table_exists?(qualified)).to be true
+    end
+
+    it 'returns false for a schema-qualified name of a missing table' do
+      create_accounts_table(db)
+
+      app = create_roda_app do
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      qualified = Sequel.qualify(:main, :does_not_exist)
+      expect(rodauth_instance.table_exists?(qualified)).to be false
+    end
+
+    it 'queries db.tables only once for a full missing_tables pass (no N+1)' do
+      create_accounts_table(db)
+      app = create_roda_app do
+        enable :login, :logout
+        enable :table_guard
+        table_guard_mode :silent
+      end
+
+      rodauth_instance = app.rodauth.allocate
+      allow(db).to receive(:tables).and_call_original
+
+      rodauth_instance.missing_tables
+
+      expect(db).to have_received(:tables).at_most(:twice)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Refactors `hmac_secret_guard` and `jwt_secret_guard` to share common validation logic via a new `Rodauth::SecretGuard` module. This fixes a critical bug where enabling both features simultaneously would cause one to shadow the other, leaving only a single secret validated at boot.

## Key Changes

- **New `lib/rodauth/secret_guard.rb`**: Extracted shared, kind-parameterized logic as plain module functions (`load_from_env!`, `validate!`, `production?`, `enforce_minimum_length!`, `blank?`, `define_secret`, `warn`). Each function takes the Rodauth instance and secret kind (`:hmac` or `:jwt`) explicitly, avoiding method-name collisions.

- **Updated `hmac_secret_guard.rb` and `jwt_secret_guard.rb`**:
  - Delegate to `Rodauth::SecretGuard` functions in `post_configure` and public methods
  - Added kind-specific validation methods: `validate_hmac_secret!` and `validate_jwt_secret!` (with `validate_secrets!` as a backwards-compatible alias)
  - Changed development fallback from a constant string to a random per-process value (`SecureRandom.hex(32)`) so it cannot be mistaken for a real, persistent secret
  - Added `minimum_secret_length` configuration (enforced in production only) to reject short secrets
  - Improved blank-value handling: whitespace-only strings now treated as missing (via `blank?` helper)
  - Enhanced documentation with fail-safe production detection guidance

- **New regression test `spec/rodauth/features/secret_guard_combined_spec.rb`**: Validates that both guards can be enabled together and each secret is validated independently, regardless of enable order.

- **Updated existing tests**: Verify random fallback generation, whitespace handling, minimum length enforcement, and kind-specific validation entry points.

- **Documentation updates**: Clarified production detection patterns, explained random fallback behavior, documented minimum length feature, and added notes about collision-free method names when both guards are enabled.

- **Minor refactoring in `table_guard.rb`**: Replaced logger suppression with `db.tables` list-based existence check to avoid thread-unsafe shared-state mutation.

## Notable Implementation Details

- **Module Functions Pattern**: `Rodauth::SecretGuard` uses `module_function` so functions are called explicitly (`Rodauth::SecretGuard.load_from_env!(self, :hmac)`) rather than mixed in, eliminating the method-name surface that caused the original collision.

- **Fail-Safe Default**: The default `production_env_check` uses `ENV.fetch('RACK_ENV', 'production')` so an unset variable is treated as production, causing validation to fail closed rather than silently falling back to the insecure development secret.

- **Per-Process Randomness**: Development fallbacks are generated once per process at feature load time, making them ephemeral and unsuitable for mistaking as real secrets.

- **Backwards Compatibility**: The `validate_secrets!` alias is preserved, though documentation recommends the kind-specific methods when both guards are enabled to avoid ambiguity.

https://claude.ai/code/session_01EZ1yayvvyWiUpn7BiVSX7J