### PR TITLE
*Add account_id_obfuscation feature for email links and cookies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
+Style/OneClassPerFile:
+  Exclude:
+    - 'examples/**/*'
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,6 +154,7 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
+    - 'lib/rodauth/features/account_id_obfuscation.rb'
     - 'lib/rodauth/features/external_identity.rb'
     - 'lib/rodauth/features/hmac_secret_guard.rb'
     - 'lib/rodauth/features/jwt_secret_guard.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-05
+
+### Added
+
+- **Account ID Obfuscation feature** (`account_id_obfuscation`) - Keyed, reversible
+  obfuscation of the numeric `account_id` that leaks into email-link tokens (e.g.
+  `/verify-account?key=2_...`) and the remember-me cookie, with no database schema
+  change. Wraps the two `email_base` chokepoints (`token_param_value` /
+  `account_from_key`), so a single `enable` covers verify_account, reset_password,
+  email_auth, verify_login_change and lockout/unlock; also obfuscates the remember
+  cookie when `remember` is enabled. Loads a dedicated `ACCOUNT_ID_SECRET` following
+  the `hmac_secret_guard` pattern. Backward compatible with in-flight numeric links
+  and legacy cookies, with config-driven secret rotation via a version tag.
+- **`Rodauth::Tools::AccountIdCipher`** - Framework-agnostic 4-round Feistel
+  format-preserving encryption utility (stdlib `openssl` only, no new dependencies).
+
+## [0.3.1] - 2026-01-13
+
+### Changed
+
+- Dependency and development-tooling maintenance (bundled `rodauth`, `sequel`,
+  `rubocop`, and related updates).
+
 ## [0.3.0] - 2025-11-25
 
 ### Added
@@ -76,6 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Namespace changed from `Rodauth::Rack::Generators::Migration` to `Rodauth::Tools::Migration`
 - Evolution from Rack adapter to framework-agnostic utilities
 
+[0.4.0]: https://github.com/delano/rodauth-tools/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/delano/rodauth-tools/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/delano/rodauth-tools/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/delano/rodauth-tools/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/delano/rodauth-tools/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Framework-agnostic utilities for Rodauth authentication:
 
-1. **External Rodauth Features** - `table_guard` for database validation, `external_identity` for external service IDs, `hmac_secret_guard` for HMAC secret validation, `jwt_secret_guard` for JWT secret validation
+1. **External Rodauth Features** - `table_guard` for database validation, `external_identity` for external service IDs, `hmac_secret_guard` for HMAC secret validation, `jwt_secret_guard` for JWT secret validation, `account_id_obfuscation` for hiding numeric account ids in email links and cookies
 2. **Sequel Migration Generator** - Generate migrations for 19 Rodauth features
 
 **Not a framework adapter.** For Rails integration, use rodauth-rails. This project demonstrates Rodauth's extensibility and provides reference implementations.
@@ -57,6 +57,21 @@ bin/console
 - Deletes secret from ENV after loading for security
 - Provides `production?` and `validate_secrets!` public methods
 - Defines `jwt_secret` configuration method for standalone use
+
+**lib/rodauth/features/account_id_obfuscation.rb** - External Rodauth feature
+
+- Uses `Rodauth::Feature.define(:account_id_obfuscation, :AccountIdObfuscation)` pattern
+- Obfuscates `account_id` in email-link tokens and the remember cookie via scoped `token_param_value`/`account_from_key` (and conditional `_set_/_get_remember_cookie`) overrides
+- Never touches the global `split_token`/`convert_token_id`, so `jwt_refresh` and other token consumers are unaffected
+- Loads a dedicated `ACCOUNT_ID_SECRET` like the secret guards; `production?`/`validate_secrets!` lifecycle
+- Non-digit version tag makes legacy-vs-obfuscated deterministic and drives config-driven secret rotation
+- Delegates the crypto to the standalone `Rodauth::Tools::AccountIdCipher`
+
+**lib/rodauth/tools/account_id_cipher.rb** - Framework-agnostic utility
+
+- Keyed format-preserving obfuscation of a 64-bit integer id (4-round Feistel network, HMAC-SHA256 round function)
+- Pure `Integer <-> 13-char Crockford Base32` bijection; stdlib `openssl` only, independently testable
+- `decode` returns `nil` on malformed input so callers can pass legacy/foreign values through
 
 **lib/rodauth/tools/migration.rb** - Sequel migration generator
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rodauth-tools (0.3.1)
+    rodauth-tools (0.4.0)
       dry-inflector (~> 1.1)
       rodauth (~> 2.41)
       sequel (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,38 @@ end
 
 **Documentation:** [docs/features/jwt-secret-guard.md](docs/features/jwt-secret-guard.md)
 
-### 5. Sequel Migration Generator
+### 5. Account ID Obfuscation Feature
+
+Obfuscate the numeric `account_id` that leaks into email-verification links and the
+remember-me cookie, with no database schema change.
+
+```ruby
+class RodauthApp < Roda
+  plugin :rodauth do
+    enable :login, :verify_account, :remember
+    enable :account_id_obfuscation
+
+    # Production: raises error if ACCOUNT_ID_SECRET (>= 32 bytes) missing
+    # Development: uses fallback secret with warning
+  end
+end
+```
+
+Links change from `/verify-account?key=2_SspVz...` to `/verify-account?key=A9F3K2M0QALZ7T_SspVz...`.
+
+**Key Features:**
+
+- Keyed, reversible obfuscation (4-round Feistel format-preserving encryption)
+- Covers all email-link features + the remember cookie via two scoped overrides
+- Leaves `split_token`/`convert_token_id` untouched, so `jwt_refresh` is unaffected
+- Backward compatible: in-flight numeric links and legacy cookies keep working
+- Version-tagged tokens enable config-driven secret rotation
+- Dedicated `ACCOUNT_ID_SECRET` (>= 32 bytes), independent of HMAC/JWT secrets
+- Standalone `Rodauth::Tools::AccountIdCipher` primitive (stdlib `openssl` only)
+
+**Documentation:** [docs/features/account-id-obfuscation.md](docs/features/account-id-obfuscation.md)
+
+### 6. Sequel Migration Generator
 
 Generate database migrations for Rodauth features.
 
@@ -306,6 +337,7 @@ Rodauth Features are modules that mix into `Rodauth::Auth` instances at runtime.
 - **[External Identity Feature](docs/features/external-identity.md)** - Track external service identifiers
 - **[HMAC Secret Guard Feature](docs/features/hmac-secret-guard.md)** - Validate HMAC secrets at startup
 - **[JWT Secret Guard Feature](docs/features/jwt-secret-guard.md)** - Validate JWT secrets at startup
+- **[Account ID Obfuscation Feature](docs/features/account-id-obfuscation.md)** - Hide numeric account ids in email links and cookies
 - **[Sequel Migrations](docs/sequel-migrations.md)** - Integrating table_guard with Sequel migrations
 - **[Rodauth Feature API](docs/rodauth-features-api.md)** - Complete DSL reference for feature development
 - **[Rodauth Integration](docs/rodauth-integration.md)** - Framework integration patterns

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ class RodauthApp < Roda
 end
 ```
 
-Links change from `/verify-account?key=2_SspVz...` to `/verify-account?key=A9F3K2M0QALZ7T_SspVz...`.
+Links change from `/verify-account?key=2_SspVz...` to `/verify-account?key=AE946V4SD7Z7RV_SspVz...`.
 
 **Key Features:**
 

--- a/docs/features/account-id-obfuscation.md
+++ b/docs/features/account-id-obfuscation.md
@@ -14,7 +14,7 @@ https://example.com/verify-account?key=2_SspVzDfIxrn3wzZ97lLQVZ6i9QO4VZkIaW2Wz0M
 With this feature enabled it becomes:
 
 ```text
-https://example.com/verify-account?key=A9F3K2M0QALZ7T_SspVzDfIxrn3wzZ97lLQVZ6i9QO4VZkIaW2Wz0MU_s8
+https://example.com/verify-account?key=AE946V4SD7Z7RV_SspVzDfIxrn3wzZ97lLQVZ6i9QO4VZkIaW2Wz0MU_s8
 ```
 
 The integer primary key is still used everywhere internally; only the value that
@@ -43,7 +43,7 @@ feature overrides two `email_base` methods:
   integer before Rodauth's normal verification runs.
 
 The obfuscated id is `<version><13 Crockford-Base32 chars>` (14 chars total), e.g.
-`A9F3K2M0QALZ7T`. The `<version>` is a single **non-digit** character (`A` by
+`AE946V4SD7Z7RV`. The `<version>` is a single **non-digit** character (`A` by
 default). Because Rodauth's legacy ids are always decimal digits, the version tag
 makes "is this obfuscated or a legacy id?" a deterministic first-character test —
 which is what guarantees backward compatibility (see below).
@@ -51,7 +51,10 @@ which is what guarantees backward compatibility (see below).
 The underlying transform is `Rodauth::Tools::AccountIdCipher`: a 4-round Feistel
 network keyed with HMAC-SHA256 (keyed format-preserving encryption). It is a
 bijection over the 64-bit domain, so every id maps to exactly one token and back,
-with no collisions.
+with no collisions. `decode` also rejects the rare well-formed-but-non-canonical
+token (13 Crockford chars encode 65 bits for a 64-bit block, so each id has one
+canonical token and one non-canonical near-duplicate) by re-encoding and comparing,
+so decode is a strict inverse of encode rather than 2-to-1.
 
 ### Scoped overrides
 
@@ -61,6 +64,21 @@ This feature deliberately does **not** override the lower-level `split_token` /
 remember cookie), the blast radius is exactly the surfaces that leak `account_id`
 in a user-visible URL or cookie. `internal_request` delegates through the override
 untouched.
+
+The remember-cookie wrapper (`_set_remember_cookie`/`_get_remember_cookie`) is
+defined once as an ordinary method in this feature's module, guarded internally by
+`account_id_obfuscation_remember_cookie?`/`features.include?(:remember)`, rather
+than installed per-instance from `post_configure`. `internal_request` re-runs
+`post_configure` on an internally-created subclass of the already-configured Auth
+class; a per-instance install would run again there and define a second override
+whose `super` resolved to the first override instead of to `remember.rb`,
+double-obfuscating the id and raising on the resulting non-decimal string. A
+method defined once in the module has exactly one place for `super` to resolve to,
+regardless of how many subclasses `post_configure` runs on. One consequence: this
+relies on `account_id_obfuscation` being enabled *after* `remember` (`enable
+:login, :remember, :account_id_obfuscation`, as shown throughout this doc) so it
+sits above `remember` in the ancestor chain; enabling it before `remember` means
+`remember`'s own method wins the chain and the cookie is left un-obfuscated.
 
 ## Configuration
 
@@ -128,9 +146,19 @@ behaviour). Proc or Boolean.
 
 **Default:** `proc { ENV.fetch('RACK_ENV', 'production') == 'production' }`
 
+This is the *same* config method (and, when this feature is co-enabled with
+`hmac_secret_guard`/`jwt_secret_guard`, potentially the *same* stored value) that
+those two guards read via `Rodauth::SecretGuard.production?`. Setting it once
+configures production detection for whichever of these secret-lifecycle features
+you have enabled. As with the guards, avoid `proc { ENV['RACK_ENV'] == 'production' }`
+— when the variable is unset that returns `false` and silently falls back to the
+insecure development secret in what is really a production deploy; the default
+above fails safe instead by treating an unset `RACK_ENV` as production.
+
 ### `validate_secrets_on_configure?`
 
-Enable/disable secret validation during the `post_configure` hook.
+Enable/disable secret validation during the `post_configure` hook. Shared name
+and semantics with `hmac_secret_guard`/`jwt_secret_guard`.
 
 **Default:** `true`
 
@@ -139,6 +167,13 @@ Enable/disable secret validation during the `post_configure` hook.
 Fallback secret (>= 32 bytes) used in development when none is configured.
 
 **Default:** `'dev-only-insecure-account-id-obfuscation-secret-please-change-me'`
+
+Unlike the sibling guards' `SecureRandom.hex`-per-process fallback, this default is
+a **fixed** string, deliberately. Obfuscated tokens have no server-side session to
+fall back on: if the fallback secret changed on every process restart, every
+in-flight email link and remember cookie minted before a development restart would
+stop decoding. Determinism across restarts is the point here — it does not make the
+value any less of a "change this before production" placeholder.
 
 ### Error / warning messages
 
@@ -164,11 +199,21 @@ end
 ### Public methods
 
 ```ruby
-rodauth.obfuscate_account_id(2)      # => "A9F3K2M0QALZ7T"
-rodauth.deobfuscate_account_id(tok)  # => 2, or nil if tok is not one of our tokens
-rodauth.production?                  # => true or false
-rodauth.validate_secrets!            # manual secret validation
+rodauth.obfuscate_account_id(2)                       # => "AE946V4SD7Z7RV"
+rodauth.deobfuscate_account_id(tok)                    # => 2, or nil if tok is not one of our tokens
+rodauth.production?                                    # => true or false
+rodauth.validate_account_id_obfuscation_secret!        # manual secret validation (unambiguous)
+rodauth.validate_secrets!                              # alias for the above — see caveat below
 ```
+
+**`validate_secrets!` is a collision-prone alias.** `hmac_secret_guard` and
+`jwt_secret_guard` each define their *own* `validate_secrets!` that validates a
+completely different secret. When any of these features are co-enabled, whichever
+definition is last in the method-resolution order wins for *all* of them —
+`post_configure` never calls the bare name for exactly this reason (it calls
+`validate_account_id_obfuscation_secret!` directly). Prefer the fully-qualified
+method name for manual calls too; only reach for `validate_secrets!` when you know
+this is the only one of the three features enabled.
 
 ## Backward Compatibility
 
@@ -177,7 +222,7 @@ Rollout and rollback are safe with no schema or data migration:
 - **In-flight email links.** A legacy link carries a decimal id segment
   (`2_abc...`). On decode, `deobfuscate_account_id('2')` returns `nil` (a legacy
   decimal has no version prefix), so the token passes through to Rodauth unchanged.
-  Newly generated links carry `A9F3...`. Both work during and after rollout.
+  Newly generated links carry `AE946...`. Both work during and after rollout.
 - **Legacy remember cookies.** Same rule: a numeric cookie id has no version prefix,
   so it is used as-is. Existing logged-in users are **not** forced to re-login.
 - **Rollback.** Remove `enable :account_id_obfuscation`. New links/cookies revert to
@@ -197,6 +242,13 @@ schedule using version-keyed selection:
 1. Generate a new secret and pick a new version char (e.g. `B`).
 2. Move the current secret into `account_id_obfuscation_previous_secrets` under its
    old version char.
+
+Every version char (current + all previous) is validated at boot: each must be a
+single non-digit character, distinct from `token_separator` and `_`, and distinct
+from every other version char in use. A digit, a duplicate, or a
+`previous_secrets` entry shorter than 32 bytes all raise `Rodauth::ConfigurationError`
+immediately at `post_configure` — rotation mistakes fail closed at deploy time
+rather than surfacing as silent decode failures later.
 
 ```ruby
 plugin :rodauth do
@@ -244,8 +296,8 @@ confidential data.**
 
 ```ruby
 cipher = Rodauth::Tools::AccountIdCipher.new(ENV.fetch('ACCOUNT_ID_SECRET'))
-cipher.encode(2)            # => "9F3K2M0QALZ7T"  (13 chars, no version tag)
-cipher.decode('9F3K2M0QALZ7T')  # => 2
+cipher.encode(2)              # => "E946V4SD7Z7RV"  (13 chars, no version tag)
+cipher.decode('E946V4SD7Z7RV')  # => 2
 cipher.decode('not-a-token')    # => nil
 ```
 

--- a/docs/features/account-id-obfuscation.md
+++ b/docs/features/account-id-obfuscation.md
@@ -1,0 +1,297 @@
+# Account ID Obfuscation Feature
+
+Obfuscate the numeric `account_id` that Rodauth otherwise leaks in plaintext inside
+email-verification links and the remember-me cookie — without changing your database
+schema.
+
+By default, a verification link looks like this, with the leading `2` being the
+account's integer primary key:
+
+```text
+https://example.com/verify-account?key=2_SspVzDfIxrn3wzZ97lLQVZ6i9QO4VZkIaW2Wz0MU_s8
+```
+
+With this feature enabled it becomes:
+
+```text
+https://example.com/verify-account?key=A9F3K2M0QALZ7T_SspVzDfIxrn3wzZ97lLQVZ6i9QO4VZkIaW2Wz0MU_s8
+```
+
+The integer primary key is still used everywhere internally; only the value that
+crosses the network is obfuscated.
+
+## Installation
+
+```ruby
+enable :account_id_obfuscation
+```
+
+The feature depends on `email_base` (auto-enabled). It wraps the two email-token
+chokepoints that all email-link features share, so a single `enable` covers
+`verify_account`, `reset_password`, `email_auth`, `verify_login_change` and
+`lockout`/`unlock`. When `remember` is also enabled, the remember-me cookie is
+obfuscated too.
+
+## How It Works
+
+Rodauth email tokens are `<account_id><token_separator><random-or-HMAC-key>`. This
+feature overrides two `email_base` methods:
+
+- **`token_param_value`** (encode) — rewrites the `<account_id>` segment of the
+  outgoing token to a version-tagged, obfuscated form.
+- **`account_from_key`** (decode) — swaps the obfuscated segment back to the real
+  integer before Rodauth's normal verification runs.
+
+The obfuscated id is `<version><13 Crockford-Base32 chars>` (14 chars total), e.g.
+`A9F3K2M0QALZ7T`. The `<version>` is a single **non-digit** character (`A` by
+default). Because Rodauth's legacy ids are always decimal digits, the version tag
+makes "is this obfuscated or a legacy id?" a deterministic first-character test —
+which is what guarantees backward compatibility (see below).
+
+The underlying transform is `Rodauth::Tools::AccountIdCipher`: a 4-round Feistel
+network keyed with HMAC-SHA256 (keyed format-preserving encryption). It is a
+bijection over the 64-bit domain, so every id maps to exactly one token and back,
+with no collisions.
+
+### Scoped overrides
+
+This feature deliberately does **not** override the lower-level `split_token` /
+`convert_token_id`, which are shared by other token consumers such as
+`jwt_refresh`. By transforming only the id segment at the two email seams (and the
+remember cookie), the blast radius is exactly the surfaces that leak `account_id`
+in a user-visible URL or cookie. `internal_request` delegates through the override
+untouched.
+
+## Configuration
+
+### `account_id_obfuscation_secret`
+
+The obfuscation key. Must be at least 32 bytes. Leave unset to auto-load it from the
+environment (see `account_id_obfuscation_secret_env_key`).
+
+**Default:** `nil`
+
+```ruby
+account_id_obfuscation_secret ENV['ACCOUNT_ID_SECRET']
+```
+
+### `account_id_obfuscation_secret_env_key`
+
+Environment variable name to read the secret from. The value is read **and deleted**
+from `ENV` at configure time (same as `hmac_secret_guard`).
+
+**Default:** `"ACCOUNT_ID_SECRET"`
+
+```ruby
+account_id_obfuscation_secret_env_key 'MY_ID_SECRET'
+```
+
+### `account_id_obfuscation_key_version`
+
+Single, **non-digit** character prepended to each obfuscated token. Selects the
+secret used to encode/decode and drives rotation. Must not be a digit, the
+`token_separator`, or `_`.
+
+**Default:** `'A'`
+
+```ruby
+account_id_obfuscation_key_version 'B'
+```
+
+### `account_id_obfuscation_previous_secrets`
+
+Map of `{ version_char => old_secret }` consulted **only on decode**, to keep
+tokens minted under a retired secret working during rotation. Defaults to empty, so
+rotation is opt-in.
+
+**Default:** `{}`
+
+```ruby
+account_id_obfuscation_previous_secrets({ 'A' => ENV['ACCOUNT_ID_SECRET_OLD'] })
+```
+
+### `account_id_obfuscation_remember_cookie?`
+
+Whether to also obfuscate the remember-me cookie (only relevant when `remember` is
+enabled).
+
+**Default:** `true`
+
+```ruby
+account_id_obfuscation_remember_cookie? false
+```
+
+### `production_env_check`
+
+Determines if the application is running in production (controls missing-secret
+behaviour). Proc or Boolean.
+
+**Default:** `proc { ENV.fetch('RACK_ENV', 'production') == 'production' }`
+
+### `validate_secrets_on_configure?`
+
+Enable/disable secret validation during the `post_configure` hook.
+
+**Default:** `true`
+
+### `development_account_id_obfuscation_secret_fallback`
+
+Fallback secret (>= 32 bytes) used in development when none is configured.
+
+**Default:** `'dev-only-insecure-account-id-obfuscation-secret-please-change-me'`
+
+### Error / warning messages
+
+- `account_id_obfuscation_secret_missing_error`
+- `account_id_obfuscation_secret_too_short_error`
+- `account_id_obfuscation_key_version_error`
+- `account_id_obfuscation_secret_dev_warning`
+
+## Usage
+
+### Basic configuration
+
+```ruby
+class RodauthApp < Roda
+  plugin :rodauth do
+    enable :login, :verify_account, :remember
+    enable :account_id_obfuscation
+    # ACCOUNT_ID_SECRET is loaded from ENV and deleted after configure
+  end
+end
+```
+
+### Public methods
+
+```ruby
+rodauth.obfuscate_account_id(2)      # => "A9F3K2M0QALZ7T"
+rodauth.deobfuscate_account_id(tok)  # => 2, or nil if tok is not one of our tokens
+rodauth.production?                  # => true or false
+rodauth.validate_secrets!            # manual secret validation
+```
+
+## Backward Compatibility
+
+Rollout and rollback are safe with no schema or data migration:
+
+- **In-flight email links.** A legacy link carries a decimal id segment
+  (`2_abc...`). On decode, `deobfuscate_account_id('2')` returns `nil` (a legacy
+  decimal has no version prefix), so the token passes through to Rodauth unchanged.
+  Newly generated links carry `A9F3...`. Both work during and after rollout.
+- **Legacy remember cookies.** Same rule: a numeric cookie id has no version prefix,
+  so it is used as-is. Existing logged-in users are **not** forced to re-login.
+- **Rollback.** Remove `enable :account_id_obfuscation`. New links/cookies revert to
+  numeric; already-issued obfuscated links stop resolving (they need the feature to
+  decode) but email links are short-lived, and obfuscated remember cookies simply
+  degrade to a re-login.
+
+The non-digit version tag is what makes this deterministic: without it, a legacy
+13-digit decimal id would be indistinguishable from a 13-char obfuscated token. With
+it, there is no ambiguity for ids of any size.
+
+## Key Rotation
+
+The secret is a reversible key: changing it re-maps every id. Rotate it on its own
+schedule using version-keyed selection:
+
+1. Generate a new secret and pick a new version char (e.g. `B`).
+2. Move the current secret into `account_id_obfuscation_previous_secrets` under its
+   old version char.
+
+```ruby
+plugin :rodauth do
+  enable :account_id_obfuscation
+
+  account_id_obfuscation_key_version 'B'
+  account_id_obfuscation_secret ENV['ACCOUNT_ID_SECRET']            # new
+  account_id_obfuscation_previous_secrets({ 'A' => ENV['ACCOUNT_ID_SECRET_OLD'] })
+end
+```
+
+New tokens are minted under `B`; outstanding `A` tokens still decode. Drop the `A`
+entry once those links/cookies have expired.
+
+## Security Notes
+
+**This is deterministic pseudonymisation, not access control or encryption of
+confidential data.**
+
+- The same id always maps to the same token, so tokens are **correlatable** — an
+  observer can tell that two links reference the same account, they just can't tell
+  *which* account.
+- The obfuscation does **not** change a token's authority. The email-token HMAC (or
+  random key) still gates the request after the id is swapped back to the real
+  integer. Obfuscation is a privacy/anti-enumeration layer on top of authentication,
+  never a replacement for it.
+- Strength lives entirely in the **secret** (Kerckhoffs's principle): the design is
+  public, and knowing it does not let an attacker reverse a token without the key.
+- Use a dedicated `ACCOUNT_ID_SECRET`, independent of `hmac_secret`/`jwt_secret`, so
+  rotating one does not invalidate the others' in-flight tokens. Generate at least 32
+  bytes:
+
+  ```bash
+  openssl rand -base64 48
+  # or
+  ruby -r securerandom -e 'puts SecureRandom.hex(32)'
+  ```
+
+- Applies to **integer/bigint** primary keys. `Integer(id)` is used internally, so
+  non-numeric (e.g. UUID) primary keys are out of scope.
+
+## Standalone Cipher
+
+`Rodauth::Tools::AccountIdCipher` is framework-agnostic and usable on its own:
+
+```ruby
+cipher = Rodauth::Tools::AccountIdCipher.new(ENV.fetch('ACCOUNT_ID_SECRET'))
+cipher.encode(2)            # => "9F3K2M0QALZ7T"  (13 chars, no version tag)
+cipher.decode('9F3K2M0QALZ7T')  # => 2
+cipher.decode('not-a-token')    # => nil
+```
+
+The feature adds the version tag on top; the cipher itself is a pure
+`Integer <-> 13-char` bijection.
+
+## Testing
+
+```ruby
+RSpec.describe 'Account ID Obfuscation' do
+  it 'obfuscates the id and round-trips it' do
+    app = Class.new(Roda) do
+      plugin :rodauth do
+        db DB
+        enable :login, :verify_account, :account_id_obfuscation
+        hmac_secret 'h' * 32
+        account_id_obfuscation_secret 'a' * 40
+        production_env_check false
+      end
+      route(&:rodauth)
+    end
+
+    rodauth = app.rodauth.allocate
+    token = rodauth.obfuscate_account_id(2)
+    expect(token).to start_with('A')
+    expect(rodauth.deobfuscate_account_id(token)).to eq(2)
+    expect(rodauth.deobfuscate_account_id('2')).to be_nil # legacy id passes through
+  end
+end
+```
+
+Disable secret validation in tests that don't set a secret with
+`validate_secrets_on_configure? false`.
+
+## Related Features
+
+- **email_base** - Provides the `token_param_value`/`account_from_key` chokepoints
+  this feature wraps (dependency).
+- **remember** - When enabled, its cookie is obfuscated too.
+- **hmac_secret_guard** / **jwt_secret_guard** - Sibling secret-lifecycle features;
+  this feature follows the same ENV-load-and-delete pattern.
+- **jwt_refresh** - Unaffected: this feature never touches the global token split.
+
+## References
+
+- [Format-preserving encryption](https://en.wikipedia.org/wiki/Format-preserving_encryption)
+- [Feistel cipher](https://en.wikipedia.org/wiki/Feistel_cipher)
+- [Crockford Base32](https://www.crockford.com/base32.html)
+- [Kerckhoffs's principle](https://en.wikipedia.org/wiki/Kerckhoffs%27s_principle)

--- a/lib/rodauth/features/account_id_obfuscation.rb
+++ b/lib/rodauth/features/account_id_obfuscation.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../tools/account_id_cipher' unless defined?(Rodauth::Tools::AccountIdCipher)
+require_relative '../secret_guard' unless defined?(Rodauth::SecretGuard)
 
 module Rodauth
   # Obfuscates the numeric account id that Rodauth otherwise leaks in plaintext
@@ -30,6 +31,14 @@ module Rodauth
   # links/cookies pass through untouched. It also selects the secret, enabling
   # config-driven key rotation via +account_id_obfuscation_previous_secrets+.
   #
+  # This feature shares its ENV-loading and production-detection plumbing with
+  # +hmac_secret_guard+/+jwt_secret_guard+ via +Rodauth::SecretGuard+ (see
+  # +production_env_check+ and +validate_secrets_on_configure?+ below, which are
+  # the same config methods those two guards expose). It keeps its own
+  # always-on 32-byte minimum, though: {Rodauth::Tools::AccountIdCipher} hard-requires
+  # that floor regardless of environment, unlike the guards' opt-in, production-only
+  # +minimum_secret_length+.
+  #
   # @example
   #   plugin :rodauth do
   #     enable :login, :verify_account, :remember, :account_id_obfuscation
@@ -52,8 +61,20 @@ module Rodauth
     auth_value_method :account_id_obfuscation_key_version, 'A' # single non-digit char
     auth_value_method :account_id_obfuscation_previous_secrets, {}.freeze # {ver_char => old_secret}, decode-only
     auth_value_method :account_id_obfuscation_remember_cookie?, true
+    # Shared with hmac_secret_guard/jwt_secret_guard (same config method, same
+    # fail-safe default): an unset RACK_ENV is treated as production. Avoid
+    # `proc { ENV['RACK_ENV'] == 'production' }` — when the variable is unset
+    # that returns false and silently falls back to the insecure development
+    # secret in what is really a production deploy.
     auth_value_method :production_env_check, proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
+    # Shared with hmac_secret_guard/jwt_secret_guard: gates whether post_configure
+    # calls the boot-time validator at all.
     auth_value_method :validate_secrets_on_configure?, true
+    # Fixed (not random-per-process, unlike the guards' SecureRandom.hex fallback):
+    # obfuscated tokens must stay stable across restarts within a single
+    # development process' lifetime for links/cookies minted before a restart to
+    # keep decoding, and this feature has no server-side session to smooth that
+    # over. Still a placeholder — change it, or better, set ACCOUNT_ID_SECRET.
     auth_value_method :development_account_id_obfuscation_secret_fallback,
                       'dev-only-insecure-account-id-obfuscation-secret-please-change-me'
 
@@ -70,20 +91,16 @@ module Rodauth
     # map lazily per runtime instance rather than in an instance ivar.
     auth_cached_method :account_id_ciphers
 
-    auth_methods :obfuscate_account_id, :deobfuscate_account_id, :production?, :validate_secrets!
+    auth_methods :obfuscate_account_id, :deobfuscate_account_id, :production?,
+                 :validate_secrets!, :validate_account_id_obfuscation_secret!
 
     def post_configure
       super
 
       load_account_id_secret_from_env
       validate_key_version!
-      validate_secrets! if validate_secrets_on_configure?
+      validate_account_id_obfuscation_secret! if validate_secrets_on_configure?
 
-      # Remember's cookie read path (remembered_session_id -> _get_remember_cookie)
-      # resolves via full MRO, so our override must sit at the top of the chain
-      # regardless of enable order; installing on the subclass guarantees that and
-      # keeps the wiring conditional. (Same idiom as external_identity's
-      # account_select wrapper.)
       install_remember_cookie_obfuscation if account_id_obfuscation_remember_cookie? && features.include?(:remember)
     end
 
@@ -95,6 +112,8 @@ module Rodauth
     # email_base's exact composition.
     def token_param_value(key)
       original = super
+      return original if account_id.nil?
+
       _id, separator, remainder = original.partition(token_separator)
       remainder.empty? ? original : "#{obfuscate_account_id(account_id)}#{separator}#{remainder}"
     end
@@ -132,21 +151,41 @@ module Rodauth
       cipher.decode(segment[1..])
     end
 
+    # Check if we're running in production environment.
+    #
+    # Delegates to the same +Rodauth::SecretGuard.production?+ that
+    # +hmac_secret_guard+/+jwt_secret_guard+ use, so behavior is identical
+    # whichever guard's copy of this method happens to win when several are
+    # enabled together (see +validate_secrets!+ below for why that collision
+    # matters more for validation than for this read-only check).
+    #
+    # @return [Boolean] true if running in production mode based on production_env_check
     def production?
-      case v = production_env_check
-      when Proc then instance_exec(&v)
-      else !!v
-      end
+      Rodauth::SecretGuard.production?(self)
     end
 
-    # Ensure a usable secret is present (mirrors hmac_secret_guard): require it in
-    # production, warn + fall back in development, and always reject a
-    # present-but-too-short secret in either environment.
-    def validate_secrets!
+    # Validate that the account-id obfuscation secret(s) are properly
+    # configured. Raises ConfigurationError in production if the current
+    # secret is missing or blank. Always (in every environment) raises if the
+    # current secret, or any +account_id_obfuscation_previous_secrets+ entry,
+    # is present but shorter than +AccountIdCipher::MIN_SECRET_BYTES+ — unlike
+    # +minimum_secret_length+ on the sibling guards, this floor is not
+    # opt-in/production-only, because {Rodauth::Tools::AccountIdCipher} raises
+    # ArgumentError below it regardless of environment. In development, a
+    # missing current secret warns and installs a fallback.
+    #
+    # This is the collision-free entry point: prefer it over +validate_secrets!+
+    # when this feature is co-enabled with +hmac_secret_guard+/+jwt_secret_guard+
+    # (see +post_configure+, which calls this method by name so boot-time
+    # validation never depends on which +validate_secrets!+ wins the MRO).
+    #
+    # @raise [Rodauth::ConfigurationError] if the current or a previous secret is unusable
+    # @return [void]
+    def validate_account_id_obfuscation_secret!
       secret = account_id_obfuscation_secret
 
-      if secret.nil? || secret.to_s.empty?
-        raise Rodauth::ConfigurationError, account_id_obfuscation_secret_missing_error if production?
+      if Rodauth::SecretGuard.blank?(secret)
+        raise Rodauth::ConfigurationError, account_id_obfuscation_secret_missing_error if Rodauth::SecretGuard.production?(self)
 
         warn_dev_account_id_secret
         fallback = development_account_id_obfuscation_secret_fallback
@@ -154,9 +193,34 @@ module Rodauth
         secret = fallback
       end
 
-      return unless secret.to_s.bytesize < Rodauth::Tools::AccountIdCipher::MIN_SECRET_BYTES
+      too_short = ->(value) { value.to_s.bytesize < Rodauth::Tools::AccountIdCipher::MIN_SECRET_BYTES }
+      if too_short.call(secret) || account_id_obfuscation_previous_secrets.values.any?(&too_short)
+        raise Rodauth::ConfigurationError, account_id_obfuscation_secret_too_short_error
+      end
 
-      raise Rodauth::ConfigurationError, account_id_obfuscation_secret_too_short_error
+      # Force the version=>cipher map to build now so any other
+      # AccountIdCipher.new failure (e.g. a future stricter check) also fails
+      # closed at boot instead of lazily on first encode/decode.
+      begin
+        account_id_ciphers
+      rescue ArgumentError => e
+        raise Rodauth::ConfigurationError, e.message
+      end
+    end
+
+    # Backwards-compatible alias for +validate_account_id_obfuscation_secret!+.
+    #
+    # Note: +hmac_secret_guard+ and +jwt_secret_guard+ each define a
+    # +validate_secrets!+ of their own, so when this feature is co-enabled with
+    # either guard this name resolves to only one of them — collision-prone;
+    # not for boot. Boot-time validation does not rely on it (see
+    # +post_configure+); use +validate_account_id_obfuscation_secret!+ for an
+    # unambiguous manual call.
+    #
+    # @raise [Rodauth::ConfigurationError] if the current or a previous secret is unusable
+    # @return [void]
+    def validate_secrets!
+      validate_account_id_obfuscation_secret!
     end
 
     private
@@ -175,32 +239,60 @@ module Rodauth
     end
 
     # Consume ACCOUNT_ID_SECRET from ENV (read + delete for security), unless an
-    # explicit secret was configured.
+    # explicit secret was configured. Delegates to the same helper the sibling
+    # guards use, so a whitespace-only env value is treated as absent exactly
+    # like theirs.
     def load_account_id_secret_from_env
-      secret = account_id_obfuscation_secret
-      return unless secret.nil? || secret.to_s.empty?
-
-      env_value = ENV.delete(account_id_obfuscation_secret_env_key)
-      return unless env_value && !env_value.empty?
-
-      self.class.send(:define_method, :account_id_obfuscation_secret) { env_value }
+      Rodauth::SecretGuard.load_from_env!(self, :account_id_obfuscation)
     end
 
-    # The backward-compat guarantee rests on the version tag being a single
-    # non-digit char distinct from the separators; fail fast otherwise.
+    # The backward-compat guarantee rests on every version tag (current AND any
+    # +account_id_obfuscation_previous_secrets+ key) being a single, unique,
+    # non-digit char distinct from the separators; fail fast otherwise. A
+    # digit would be ambiguous with a legacy decimal id, and a duplicate would
+    # mean two secrets claim the same version, making rotation nondeterministic.
     def validate_key_version!
-      version = account_id_obfuscation_key_version
+      versions = [account_id_obfuscation_key_version] + account_id_obfuscation_previous_secrets.keys
+      versions.each { |version| validate_version_char!(version) }
+
+      return if versions.tally.values.all? { |count| count == 1 }
+
+      raise Rodauth::ConfigurationError, account_id_obfuscation_key_version_error
+    end
+
+    def validate_version_char!(version)
       valid = version.is_a?(String) && version.length == 1 &&
               version !~ /\d/ && version != token_separator && version != '_'
 
       raise Rodauth::ConfigurationError, account_id_obfuscation_key_version_error unless valid
     end
 
-    # Wrap the remember cookie. remember.rb hardcodes '_' (not token_separator)
+    # Wrap the remember cookie so the id segment is obfuscated on the way out and
+    # restored on the way back in. remember.rb hardcodes '_' (not token_separator)
     # as the id/key delimiter and splits with limit 2, so an HMAC key containing
     # '_' stays intact and our version-tagged id (never contains '_', never starts
     # with a digit) is safe. Legacy numeric cookies deobfuscate to nil -> passthrough.
+    #
+    # Installed directly on the Auth class (not as an ordinary module method) so
+    # the wrapper wins regardless of the order in which +remember+ and this
+    # feature are enabled: a method defined on the class itself always takes
+    # precedence over the included feature modules, whereas an ordinary module
+    # method would be shadowed by +remember+'s own +_set_/_get_remember_cookie+
+    # whenever this feature is enabled BEFORE +remember+ (silently leaving the
+    # cookie un-obfuscated).
+    #
+    # +internal_request+ re-runs +post_configure+ on an internally-created
+    # subclass of the already-configured Auth class. We must NOT re-install there:
+    # a second override on the subclass would resolve its +super+ to the parent
+    # class's override (double-obfuscating the id and crashing on
+    # +Integer("A...")+) instead of to remember.rb. Skipping the subclass leaves
+    # it inheriting the single parent-class wrapper for +_set_remember_cookie+,
+    # while +internal_request+'s own +_get_remember_cookie+ (reading the request
+    # param) still wins for internal requests since it sits higher in that
+    # subclass's ancestry.
     def install_remember_cookie_obfuscation
+      return if defined?(Rodauth::InternalRequestMethods) && is_a?(Rodauth::InternalRequestMethods)
+
       self.class.send(:define_method, :_set_remember_cookie) do |account_id, remember_key_value, deadline|
         super(obfuscate_account_id(account_id), remember_key_value, deadline)
       end

--- a/lib/rodauth/features/account_id_obfuscation.rb
+++ b/lib/rodauth/features/account_id_obfuscation.rb
@@ -1,0 +1,225 @@
+# lib/rodauth/features/account_id_obfuscation.rb
+#
+# frozen_string_literal: true
+
+require_relative '../tools/account_id_cipher' unless defined?(Rodauth::Tools::AccountIdCipher)
+
+module Rodauth
+  # Obfuscates the numeric account id that Rodauth otherwise leaks in plaintext
+  # inside email-link tokens (e.g. +/verify-account?key=2_...+) and, optionally,
+  # the remember-me cookie. The id is replaced by a fixed-width, URL-safe,
+  # non-sequential token: a one-character non-digit VERSION tag followed by the
+  # 13-char output of {Rodauth::Tools::AccountIdCipher} (keyed format-preserving
+  # encryption). No database schema change is required; the integer primary key
+  # is used everywhere internally and only the value crossing the network is
+  # obfuscated.
+  #
+  # It wraps the two email-token chokepoints in +email_base+ (+token_param_value+
+  # to encode, +account_from_key+ to decode), which together cover ALL email-link
+  # features: verify_account, reset_password, email_auth, verify_login_change and
+  # lockout/unlock. It deliberately does NOT touch the lower-level +split_token+/
+  # +convert_token_id+, so other token consumers (e.g. jwt_refresh) are unaffected.
+  #
+  # This is deterministic pseudonymisation, NOT access control or encryption of
+  # confidential data: the same id always maps to the same token, and the token's
+  # authority is unchanged (the email HMAC still gates the request after the id is
+  # swapped back to the real Integer). Applies to integer/bigint primary keys.
+  #
+  # The VERSION tag makes obfuscated tokens deterministically distinguishable from
+  # legacy decimal ids (Rodauth ids are always digits, never a letter), so legacy
+  # links/cookies pass through untouched. It also selects the secret, enabling
+  # config-driven key rotation via +account_id_obfuscation_previous_secrets+.
+  #
+  # @example
+  #   plugin :rodauth do
+  #     enable :login, :verify_account, :remember, :account_id_obfuscation
+  #     # ACCOUNT_ID_SECRET must be set (>= 32 bytes) in production
+  #   end
+  #
+  # @example Development / custom secret source
+  #   plugin :rodauth do
+  #     enable :account_id_obfuscation
+  #     account_id_obfuscation_secret_env_key 'MY_ID_SECRET'
+  #     account_id_obfuscation_remember_cookie? false
+  #   end
+  Feature.define(:account_id_obfuscation, :AccountIdObfuscation) do
+    # email_base owns the two chokepoints we wrap; depending on it guarantees it
+    # is loaded and sits lower in the ancestor chain (so our +super+ resolves).
+    depends :email_base
+
+    auth_value_method :account_id_obfuscation_secret, nil
+    auth_value_method :account_id_obfuscation_secret_env_key, 'ACCOUNT_ID_SECRET'
+    auth_value_method :account_id_obfuscation_key_version, 'A' # single non-digit char
+    auth_value_method :account_id_obfuscation_previous_secrets, {}.freeze # {ver_char => old_secret}, decode-only
+    auth_value_method :account_id_obfuscation_remember_cookie?, true
+    auth_value_method :production_env_check, proc { ENV.fetch('RACK_ENV', 'production') == 'production' }
+    auth_value_method :validate_secrets_on_configure?, true
+    auth_value_method :development_account_id_obfuscation_secret_fallback,
+                      'dev-only-insecure-account-id-obfuscation-secret-please-change-me'
+
+    translatable_method :account_id_obfuscation_secret_missing_error,
+                        'ACCOUNT_ID_SECRET environment variable must be set in production'
+    translatable_method :account_id_obfuscation_secret_too_short_error,
+                        'account id obfuscation secret must be at least 32 bytes'
+    translatable_method :account_id_obfuscation_key_version_error,
+                        'account_id_obfuscation_key_version must be a single non-digit character'
+    translatable_method :account_id_obfuscation_secret_dev_warning,
+                        '[rodauth] WARNING: Using default account id obfuscation secret for development only'
+
+    # post_configure runs on a throwaway instance, so cache the version=>cipher
+    # map lazily per runtime instance rather than in an instance ivar.
+    auth_cached_method :account_id_ciphers
+
+    auth_methods :obfuscate_account_id, :deobfuscate_account_id, :production?, :validate_secrets!
+
+    def post_configure
+      super
+
+      load_account_id_secret_from_env
+      validate_key_version!
+      validate_secrets! if validate_secrets_on_configure?
+
+      # Remember's cookie read path (remembered_session_id -> _get_remember_cookie)
+      # resolves via full MRO, so our override must sit at the top of the chain
+      # regardless of enable order; installing on the subclass guarantees that and
+      # keeps the wiring conditional. (Same idiom as external_identity's
+      # account_select wrapper.)
+      install_remember_cookie_obfuscation if account_id_obfuscation_remember_cookie? && features.include?(:remember)
+    end
+
+    # ---- email-token chokepoints (plain overrides; email_base is a dependency,
+    #      so +super+ always resolves, and internal_request delegates through) ----
+
+    # Encode the id in the outgoing email link. Wraps email_base's token
+    # ("<id><sep><hmac>") and rewrites only the id segment, staying decoupled from
+    # email_base's exact composition.
+    def token_param_value(key)
+      original = super
+      _id, separator, remainder = original.partition(token_separator)
+      remainder.empty? ? original : "#{obfuscate_account_id(account_id)}#{separator}#{remainder}"
+    end
+
+    # Decode the id segment of an incoming token before email_base parses it.
+    # A legacy plaintext token (or any non-token) deobfuscates to nil and passes
+    # through unchanged, so in-flight links keep working.
+    def account_from_key(token, status_id = nil, &)
+      if token.is_a?(String)
+        segment, separator, remainder = token.partition(token_separator)
+        if !remainder.empty? && (real_id = deobfuscate_account_id(segment))
+          token = "#{real_id}#{separator}#{remainder}"
+        end
+      end
+
+      super
+    end
+
+    # ---- public API ----
+
+    # @return [String] version-tagged obfuscated form of an account id
+    def obfuscate_account_id(id)
+      version = account_id_obfuscation_key_version
+      "#{version}#{account_id_ciphers.fetch(version).encode(id)}"
+    end
+
+    # @return [Integer, nil] the real id, or nil if +segment+ is not one of our
+    #   tokens (legacy decimal id, unknown version, wrong width, or bad chars)
+    def deobfuscate_account_id(segment)
+      return nil unless segment.is_a?(String) &&
+                        segment.length == 1 + Rodauth::Tools::AccountIdCipher::WIDTH
+
+      cipher = account_id_ciphers[segment[0]] or return nil
+
+      cipher.decode(segment[1..])
+    end
+
+    def production?
+      case v = production_env_check
+      when Proc then instance_exec(&v)
+      else !!v
+      end
+    end
+
+    # Ensure a usable secret is present (mirrors hmac_secret_guard): require it in
+    # production, warn + fall back in development, and always reject a
+    # present-but-too-short secret in either environment.
+    def validate_secrets!
+      secret = account_id_obfuscation_secret
+
+      if secret.nil? || secret.to_s.empty?
+        raise Rodauth::ConfigurationError, account_id_obfuscation_secret_missing_error if production?
+
+        warn_dev_account_id_secret
+        fallback = development_account_id_obfuscation_secret_fallback
+        self.class.send(:define_method, :account_id_obfuscation_secret) { fallback }
+        secret = fallback
+      end
+
+      return unless secret.to_s.bytesize < Rodauth::Tools::AccountIdCipher::MIN_SECRET_BYTES
+
+      raise Rodauth::ConfigurationError, account_id_obfuscation_secret_too_short_error
+    end
+
+    private
+
+    # Backing method for the +account_id_ciphers+ auth_cached_method: a
+    # {version_char => AccountIdCipher} map. The current key_version is always
+    # present; previous secrets are added for decode-only rotation support.
+    def _account_id_ciphers
+      map = {}
+      account_id_obfuscation_previous_secrets.each do |version, old_secret|
+        map[version.to_s] = Rodauth::Tools::AccountIdCipher.new(old_secret)
+      end
+      map[account_id_obfuscation_key_version] =
+        Rodauth::Tools::AccountIdCipher.new(account_id_obfuscation_secret)
+      map
+    end
+
+    # Consume ACCOUNT_ID_SECRET from ENV (read + delete for security), unless an
+    # explicit secret was configured.
+    def load_account_id_secret_from_env
+      secret = account_id_obfuscation_secret
+      return unless secret.nil? || secret.to_s.empty?
+
+      env_value = ENV.delete(account_id_obfuscation_secret_env_key)
+      return unless env_value && !env_value.empty?
+
+      self.class.send(:define_method, :account_id_obfuscation_secret) { env_value }
+    end
+
+    # The backward-compat guarantee rests on the version tag being a single
+    # non-digit char distinct from the separators; fail fast otherwise.
+    def validate_key_version!
+      version = account_id_obfuscation_key_version
+      valid = version.is_a?(String) && version.length == 1 &&
+              version !~ /\d/ && version != token_separator && version != '_'
+
+      raise Rodauth::ConfigurationError, account_id_obfuscation_key_version_error unless valid
+    end
+
+    # Wrap the remember cookie. remember.rb hardcodes '_' (not token_separator)
+    # as the id/key delimiter and splits with limit 2, so an HMAC key containing
+    # '_' stays intact and our version-tagged id (never contains '_', never starts
+    # with a digit) is safe. Legacy numeric cookies deobfuscate to nil -> passthrough.
+    def install_remember_cookie_obfuscation
+      self.class.send(:define_method, :_set_remember_cookie) do |account_id, remember_key_value, deadline|
+        super(obfuscate_account_id(account_id), remember_key_value, deadline)
+      end
+
+      self.class.send(:define_method, :_get_remember_cookie) do
+        raw = super()
+        next raw unless raw.is_a?(String)
+
+        segment, _sep, remainder = raw.partition('_')
+        !remainder.empty? && (real_id = deobfuscate_account_id(segment)) ? "#{real_id}_#{remainder}" : raw
+      end
+    end
+
+    def warn_dev_account_id_secret
+      if respond_to?(:logger) && logger
+        logger.warn(account_id_obfuscation_secret_dev_warning)
+      else
+        warn(account_id_obfuscation_secret_dev_warning)
+      end
+    end
+  end
+end

--- a/lib/rodauth/table_inspector.rb
+++ b/lib/rodauth/table_inspector.rb
@@ -97,7 +97,7 @@ module Rodauth
         next unless feature_module
 
         # Check if this feature module defines the table method
-        return feature_name if feature_module.instance_methods(false).include?(method_name)
+        return feature_name if feature_module.method_defined?(method_name, false)
       end
 
       # Fallback: try to infer from method name if not found in any feature

--- a/lib/rodauth/tools.rb
+++ b/lib/rodauth/tools.rb
@@ -12,6 +12,7 @@ end
 require_relative 'tools/version'
 require_relative 'tools/migration'
 require_relative 'tools/console_helpers'
+require_relative 'tools/account_id_cipher'
 
 # Load rodauth-tools utilities (only if Rodauth is available)
 if defined?(Rodauth)
@@ -19,6 +20,7 @@ if defined?(Rodauth)
   require_relative 'sequel_generator'
   require_relative 'features/table_guard'
   require_relative 'features/external_identity'
+  require_relative 'features/account_id_obfuscation'
 end
 
 module Rodauth

--- a/lib/rodauth/tools/account_id_cipher.rb
+++ b/lib/rodauth/tools/account_id_cipher.rb
@@ -1,0 +1,132 @@
+# lib/rodauth/tools/account_id_cipher.rb
+#
+# frozen_string_literal: true
+
+require 'openssl'
+
+module Rodauth
+  module Tools
+    # Keyed format-preserving obfuscator for integer primary keys.
+    #
+    # Turns a numeric account id (e.g. +2+) into a fixed-width, URL-safe,
+    # non-sequential token (e.g. +"9F3K2M0QALZ7T"+) and back again, WITHOUT
+    # changing the database schema. The mapping is a keyed pseudo-random
+    # permutation (a bijection) over the 64-bit domain, so:
+    #
+    # - every id maps to exactly one token and vice-versa (no collisions),
+    # - the token reveals nothing about the id or about neighbouring ids
+    #   to anyone who does not hold the secret,
+    # - +decode(encode(id)) == id+ for all ids in range.
+    #
+    # It is a 4-round Feistel network keyed with HMAC-SHA256. This is genuine
+    # keyed encryption over a small domain (format-preserving encryption),
+    # not a reversible "encoder" like Hashids/Sqids: without the secret the
+    # permutation cannot be inverted or distinguished from random.
+    #
+    # The output alphabet is Crockford Base32, which deliberately excludes the
+    # +_+ character so encoded ids never collide with Rodauth's +token_separator+.
+    #
+    # This class is a pure +Integer <-> 13-char+ bijection: it knows nothing
+    # about versions, prefixes or legacy formats. The +account_id_obfuscation+
+    # feature adds a one-character non-digit version prefix on top (which is what
+    # makes obfuscated tokens deterministically distinguishable from legacy
+    # decimal ids and drives key rotation), keeping this primitive reusable and
+    # trivially testable in isolation.
+    #
+    # @example
+    #   cipher = Rodauth::Tools::AccountIdCipher.new(ENV.fetch('ACCOUNT_ID_SECRET'))
+    #   token  = cipher.encode(2)     # => "9F3K2M0QALZ7T" (13 chars)
+    #   cipher.decode(token)          # => 2
+    #   cipher.decode('not-a-token')  # => nil
+    class AccountIdCipher
+      MASK32 = 0xFFFF_FFFF
+      MASK64 = 0xFFFF_FFFF_FFFF_FFFF
+      ROUNDS = 4
+
+      # Crockford Base32 (no I, L, O, U; no underscore). 13 chars encodes 65 bits,
+      # covering the full 64-bit domain with a fixed, padding-free width.
+      ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+      WIDTH = 13
+
+      # Minimum secret length. HMAC-SHA256's block size is 64 bytes; 32 bytes
+      # (256 bits) is the smallest key we accept as cryptographically adequate.
+      MIN_SECRET_BYTES = 32
+
+      # @param secret [String] a high-entropy key of at least 32 bytes. Keep this
+      #   independent of +hmac_secret+ so rotating the HMAC secret does not
+      #   invalidate in-flight obfuscated ids.
+      # @raise [ArgumentError] if the secret is shorter than 32 bytes.
+      def initialize(secret)
+        secret = secret.to_s
+        raise ArgumentError, "secret must be at least #{MIN_SECRET_BYTES} bytes" if secret.bytesize < MIN_SECRET_BYTES
+
+        @secret = secret
+      end
+
+      # Encode an integer id into its fixed-width obfuscated token.
+      #
+      # @param id [Integer, #to_i] the numeric account id
+      # @return [String] a 13-character Crockford Base32 token
+      def encode(id)
+        base32(feistel(Integer(id) & MASK64, :encrypt))
+      end
+
+      # Decode an obfuscated token back into its integer id.
+      #
+      # Returns +nil+ for anything that is not a well-formed 13-char token (wrong
+      # length, illegal character, non-string), so callers can pass foreign input
+      # through without raising.
+      #
+      # @param token [String] a token previously produced by {#encode}
+      # @return [Integer, nil] the original id, or nil if +token+ is not valid
+      def decode(token)
+        number = unbase32(token)
+        number && feistel(number, :decrypt)
+      end
+
+      private
+
+      # 4-round Feistel network. Encryption runs the round schedule forward;
+      # decryption runs it in reverse, which inverts the permutation exactly.
+      def feistel(block, direction)
+        left  = (block >> 32) & MASK32
+        right = block & MASK32
+
+        schedule = (0...ROUNDS).to_a
+        schedule = schedule.reverse if direction == :decrypt
+
+        schedule.each do |round_index|
+          left, right = right, (left ^ round_function(round_index, right))
+        end
+
+        ((right << 32) | left) & MASK64
+      end
+
+      # Keyed round function: HMAC-SHA256 over the round index and half-block,
+      # folded to 32 bits. Domain-separating on the round index keeps the
+      # per-round subkeys independent.
+      def round_function(round_index, half)
+        digest = OpenSSL::HMAC.digest('SHA256', @secret, [round_index, half].pack('C N'))
+        digest.unpack1('N')
+      end
+
+      # Little-endian Crockford Base32, fixed 13 chars.
+      def base32(number)
+        Array.new(WIDTH) { |i| ALPHABET[(number >> (5 * i)) & 31] }.reverse.join
+      end
+
+      # Inverse of {#base32}. Returns nil (never raises) on malformed input so
+      # {#decode} can treat legacy/foreign values as "not one of ours".
+      def unbase32(token)
+        return nil unless token.is_a?(String) && token.length == WIDTH
+
+        token.each_char.reduce(0) do |acc, char|
+          value = ALPHABET.index(char)
+          return nil unless value
+
+          (acc << 5) | value
+        end & MASK64
+      end
+    end
+  end
+end

--- a/lib/rodauth/tools/account_id_cipher.rb
+++ b/lib/rodauth/tools/account_id_cipher.rb
@@ -9,19 +9,24 @@ module Rodauth
     # Keyed format-preserving obfuscator for integer primary keys.
     #
     # Turns a numeric account id (e.g. +2+) into a fixed-width, URL-safe,
-    # non-sequential token (e.g. +"9F3K2M0QALZ7T"+) and back again, WITHOUT
+    # non-sequential token (e.g. +"E946V4SD7Z7RV"+) and back again, WITHOUT
     # changing the database schema. The mapping is a keyed pseudo-random
     # permutation (a bijection) over the 64-bit domain, so:
     #
     # - every id maps to exactly one token and vice-versa (no collisions),
     # - the token reveals nothing about the id or about neighbouring ids
     #   to anyone who does not hold the secret,
-    # - +decode(encode(id)) == id+ for all ids in range.
+    # - +decode(encode(id)) == id+ for all ids in range, and +decode+ rejects
+    #   any well-formed-but-non-canonical token (see {#decode}).
     #
     # It is a 4-round Feistel network keyed with HMAC-SHA256. This is genuine
     # keyed encryption over a small domain (format-preserving encryption),
     # not a reversible "encoder" like Hashids/Sqids: without the secret the
-    # permutation cannot be inverted or distinguished from random.
+    # permutation is hard to invert and, for a bounded number of observed
+    # tokens, hard to distinguish from random. As with any small-block Feistel
+    # construction, that only holds up to the birthday bound of the 32-bit
+    # half-block (roughly 2^16 tokens observed under one secret) — it is not
+    # an unconditional guarantee at unbounded query volume.
     #
     # The output alphabet is Crockford Base32, which deliberately excludes the
     # +_+ character so encoded ids never collide with Rodauth's +token_separator+.
@@ -35,7 +40,7 @@ module Rodauth
     #
     # @example
     #   cipher = Rodauth::Tools::AccountIdCipher.new(ENV.fetch('ACCOUNT_ID_SECRET'))
-    #   token  = cipher.encode(2)     # => "9F3K2M0QALZ7T" (13 chars)
+    #   token  = cipher.encode(2)     # => "E946V4SD7Z7RV" (13 chars)
     #   cipher.decode(token)          # => 2
     #   cipher.decode('not-a-token')  # => nil
     class AccountIdCipher
@@ -65,7 +70,10 @@ module Rodauth
 
       # Encode an integer id into its fixed-width obfuscated token.
       #
-      # @param id [Integer, #to_i] the numeric account id
+      # @param id [Integer, String] the numeric account id, parsed with the
+      #   strict Kernel#Integer — unlike #to_i, a non-integer String (or other
+      #   value Integer() rejects) raises ArgumentError rather than silently
+      #   truncating.
       # @return [String] a 13-character Crockford Base32 token
       def encode(id)
         base32(feistel(Integer(id) & MASK64, :encrypt))
@@ -75,13 +83,23 @@ module Rodauth
       #
       # Returns +nil+ for anything that is not a well-formed 13-char token (wrong
       # length, illegal character, non-string), so callers can pass foreign input
-      # through without raising.
+      # through without raising. Also returns +nil+ for a well-formed-but-
+      # non-canonical token: 13 Crockford chars encode 65 bits for a 64-bit
+      # block, so each id has exactly one canonical 13-char token but a second,
+      # non-canonical encoding that differs only in the (discarded) 65th bit of
+      # its first character. Re-encoding the decrypted id and comparing against
+      # the input rejects that non-canonical form, keeping {#decode} a strict
+      # inverse of {#encode} rather than a 2-to-1 mapping.
       #
       # @param token [String] a token previously produced by {#encode}
-      # @return [Integer, nil] the original id, or nil if +token+ is not valid
+      # @return [Integer, nil] the original id, or nil if +token+ is not a
+      #   valid, canonical token
       def decode(token)
         number = unbase32(token)
-        number && feistel(number, :decrypt)
+        return nil unless number
+
+        id = feistel(number, :decrypt)
+        encode(id) == token ? id : nil
       end
 
       private

--- a/lib/rodauth/tools/migration.rb
+++ b/lib/rodauth/tools/migration.rb
@@ -158,8 +158,9 @@ module Rodauth
       #
       # PostgreSQL: Use native jsonb type for efficient JSON storage and querying
       # MySQL: Use native json type (supported since MySQL 5.7.8)
-      # SQLite: Use String type - SQLite stores JSON as text, but has JSON1 extension
-      #         for querying. Sequel doesn't have a :json type for SQLite.
+      # SQLite: Use String type (via the fallback below) - SQLite stores JSON as
+      #         text, but has JSON1 extension for querying. Sequel doesn't have
+      #         a :json type for SQLite.
       # Other: Fall back to String for maximum compatibility
       def json_type
         case db.database_type
@@ -167,8 +168,6 @@ module Rodauth
           ':jsonb'
         when :mysql
           ':json'
-        when :sqlite
-          String
         else
           String
         end

--- a/lib/rodauth/tools/version.rb
+++ b/lib/rodauth/tools/version.rb
@@ -4,6 +4,6 @@
 
 module Rodauth
   module Tools
-    VERSION = '0.3.1'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb
+++ b/spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe 'AccountIdObfuscation' do
       String :email, null: false
       Integer :status_id, default: 2
     end
+    d.create_table(:account_remember_keys) do
+      foreign_key :id, :accounts, primary_key: true, type: :Bignum
+      String :key, null: false
+      DateTime :deadline
+    end
     d[:accounts].insert(email: 'user@example.com', status_id: 2) # id = 1
     d
   end
@@ -50,6 +55,16 @@ RSpec.describe 'AccountIdObfuscation' do
     $stderr.string
   ensure
     $stderr = old_stderr
+  end
+
+  # Stubs +response+/+request+ on a Rodauth instance so +_set_remember_cookie+
+  # can run outside a real HTTP cycle. Returns the Hash that
+  # Rack::Utils.set_cookie_header! writes into, keyed by header name.
+  def stub_cookie_write(rodauth)
+    headers = {}
+    rodauth.define_singleton_method(:response) { Struct.new(:headers).new(headers) }
+    rodauth.define_singleton_method(:request) { Struct.new(:ssl?).new(false).tap { |s| def s.ssl? = false } }
+    headers
   end
 
   describe 'enabling the feature' do
@@ -167,6 +182,60 @@ RSpec.describe 'AccountIdObfuscation' do
     end
   end
 
+  describe 'rotation input validation (Findings #4, #5)' do
+    it 'raises for a digit previous-version key' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_previous_secrets({ '1' => 'b' * 40 })
+          production_env_check false
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /single non-digit/)
+    end
+
+    it 'raises when a previous-version key collides with the current version' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_key_version 'A' # default, spelled out for clarity
+          account_id_obfuscation_previous_secrets({ 'A' => 'b' * 40 })
+          production_env_check false
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /single non-digit/)
+    end
+
+    it 'raises when a previous secret is shorter than 32 bytes, at boot rather than lazily' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_key_version 'B'
+          account_id_obfuscation_previous_secrets({ 'A' => 'too-short' })
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /at least 32 bytes/)
+    end
+
+    it 'accepts multiple distinct previous-version keys without a false-positive collision' do
+      rodauth = create_roda_app do
+        enable :account_id_obfuscation
+        account_id_obfuscation_secret 'a' * 40
+        account_id_obfuscation_key_version 'C'
+        account_id_obfuscation_previous_secrets({ 'A' => 'x' * 40, 'B' => 'y' * 40 })
+        production_env_check false
+      end.rodauth.allocate
+
+      expect(rodauth.obfuscate_account_id(1)).to start_with('C')
+    end
+
+    it 'still deobfuscates a 14-digit legacy id to nil under a valid config' do
+      rodauth = default_app.rodauth.allocate
+      expect(rodauth.deobfuscate_account_id('12345678901234')).to be_nil
+    end
+  end
+
   describe 'key version validation' do
     it 'raises for a digit version tag' do
       expect do
@@ -207,6 +276,16 @@ RSpec.describe 'AccountIdObfuscation' do
       expect do
         create_roda_app do
           enable :account_id_obfuscation
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /ACCOUNT_ID_SECRET/)
+    end
+
+    it 'raises in production when the secret is present but blank (whitespace-only)' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret ' ' * 40
           production_env_check true
         end
       end.to raise_error(Rodauth::ConfigurationError, /ACCOUNT_ID_SECRET/)
@@ -293,20 +372,73 @@ RSpec.describe 'AccountIdObfuscation' do
       end
     end
 
-    it 'installs the cookie overrides on the Auth subclass when remember is enabled' do
-      auth = remember_app.rodauth
-      expect(auth.instance_method(:_get_remember_cookie).owner).to eq(auth)
-      expect(auth.instance_method(:_set_remember_cookie).owner).to eq(auth)
+    it 'round-trips: writes an obfuscated cookie, then reads the real id back out of it' do
+      r = remember_app.rodauth.allocate
+      headers = stub_cookie_write(r)
+
+      r.send(:_set_remember_cookie, 1, 'remkey', Time.now + 1000)
+      raw_value = headers.values.join[/_remember=([^;]+)/, 1]
+      expect(raw_value).not_to be_nil
+      expect(raw_value).to start_with(r.obfuscate_account_id(1))
+
+      fake_request = Struct.new(:cookies).new({ '_remember' => raw_value })
+      r.define_singleton_method(:request) { fake_request }
+
+      # remember.rb's own cookie value is "<id>_<converted key>"; the key half
+      # is opaque here (an HMAC, not the raw value) -- only the id half is
+      # ours to deobfuscate, so compare against the same conversion.
+      expect(r.send(:_get_remember_cookie)).to eq("1_#{r.send(:convert_token_key, "remkey")}")
     end
 
-    it 'does not install the overrides when the toggle is off' do
-      auth = remember_app(obfuscate_cookie: false).rodauth
-      expect(auth.instance_method(:_get_remember_cookie).owner).not_to eq(auth)
+    it 'with the toggle off, writes a byte-identical cookie header to stock remember' do
+      deadline = Time.now + 1000
+
+      off = remember_app(obfuscate_cookie: false).rodauth.allocate
+      off_headers = stub_cookie_write(off)
+      off.send(:_set_remember_cookie, 1, 'remkey', deadline)
+
+      stock = create_roda_app do
+        enable :login, :remember
+        hmac_secret 'h' * 32
+      end.rodauth.allocate
+      stock_headers = stub_cookie_write(stock)
+      stock.send(:_set_remember_cookie, 1, 'remkey', deadline)
+
+      expect(off_headers).to eq(stock_headers)
     end
 
-    it 'does not install the overrides when remember is not enabled' do
+    # Regression test: the remember-cookie wrapper is installed directly on the
+    # Auth class so it wins no matter where account_id_obfuscation sits relative
+    # to remember in the enable list. An earlier design used ordinary module
+    # methods, which remember's own _set_remember_cookie silently shadowed (thus
+    # skipping obfuscation) whenever this feature was enabled BEFORE remember.
+    [%i[login remember account_id_obfuscation],
+     %i[account_id_obfuscation login remember]].each do |feature_order|
+      it "obfuscates the remember cookie regardless of enable order (#{feature_order.join(", ")})" do
+        app = create_roda_app do
+          enable(*feature_order)
+          hmac_secret 'h' * 32
+          account_id_obfuscation_secret 'a' * 40
+          production_env_check false
+        end
+        r = app.rodauth.allocate
+        headers = stub_cookie_write(r)
+
+        r.send(:_set_remember_cookie, 1, 'remkey', Time.now + 1000)
+        raw_value = headers.values.join[/_remember=([^;]+)/, 1]
+
+        expect(raw_value).not_to be_nil
+        expect(raw_value).to start_with(r.obfuscate_account_id(1))
+        expect(raw_value).not_to start_with('1_') # never the plaintext id
+      end
+    end
+
+    it 'does not install the cookie overrides when remember is not enabled' do
+      # default_app enables account_id_obfuscation WITHOUT remember, so
+      # install_remember_cookie_obfuscation is never called and the class-level
+      # overrides never exist -- nothing to wrap, no accidental interference.
       auth = default_app.rodauth
-      expect(auth.private_instance_methods).not_to include(:_get_remember_cookie)
+      expect(auth.private_instance_methods).not_to include(:_set_remember_cookie, :_get_remember_cookie)
     end
 
     it 'decodes the id segment of an obfuscated cookie on read' do
@@ -346,6 +478,72 @@ RSpec.describe 'AccountIdObfuscation' do
       # These remain owned by Rodauth's base feature, not our subclass/feature.
       expect(auth.instance_method(:split_token).owner).not_to eq(auth)
       expect(auth.instance_method(:convert_token_id).owner).not_to eq(auth)
+    end
+  end
+
+  describe 'internal_request composition (Finding #2 regression net)' do
+    it 'does not double-obfuscate (or crash) the remember cookie through the internal_request subclass' do
+      app = create_roda_app do
+        enable :login, :remember, :account_id_obfuscation, :internal_request
+        hmac_secret 'h' * 32
+        account_id_obfuscation_secret 'a' * 40
+        production_env_check false
+      end
+
+      # internal_request's own post_configure creates this subclass of the
+      # already-configured Auth class and re-runs post_configure on it -- the
+      # exact scenario that used to double-install the cookie override.
+      internal_class = app.rodauth.const_get(:InternalRequest)
+      r = internal_class.allocate
+      headers = stub_cookie_write(r)
+
+      expect { r.send(:_set_remember_cookie, 1, 'remkey', Time.now + 1000) }.not_to raise_error
+
+      raw_value = headers.values.join[/_remember=([^;]+)/, 1]
+      # Single-obfuscation: the id half is exactly obfuscate_account_id(1). If
+      # the old bug were present, the id passed to remember.rb's real
+      # _set_remember_cookie would itself be an obfuscated (non-decimal)
+      # string, and Integer() on it inside a second round of obfuscation would
+      # have raised before we ever got here.
+      expect(raw_value).to start_with(r.obfuscate_account_id(1))
+    end
+  end
+
+  describe 'multi-guard co-enablement (Finding #1 regression net)' do
+    before { %w[ACCOUNT_ID_SECRET HMAC_SECRET JWT_SECRET].each { |k| ENV.delete(k) } }
+    after { %w[ACCOUNT_ID_SECRET HMAC_SECRET JWT_SECRET].each { |k| ENV.delete(k) } }
+
+    {
+      hmac_secret_guard: { env: 'HMAC_SECRET', error: /HMAC_SECRET/ },
+      jwt_secret_guard: { env: 'JWT_SECRET', error: /JWT_SECRET/ }
+    }.each do |guard, cfg|
+      [[guard, :account_id_obfuscation], [:account_id_obfuscation, guard]].each do |order|
+        context "with #{guard} + account_id_obfuscation enabled in order #{order.inspect}" do
+          it 'still raises the ACCOUNT_ID_SECRET error when the sibling guard secret is present ' \
+             'but ACCOUNT_ID_SECRET is not (the collision this feature used to hide behind)' do
+            ENV[cfg[:env]] = 'g' * 40
+
+            expect do
+              create_roda_app do
+                enable(*order)
+                production_env_check true
+              end
+            end.to raise_error(Rodauth::ConfigurationError, /ACCOUNT_ID_SECRET/)
+          end
+
+          it "still raises #{guard}'s own error when ACCOUNT_ID_SECRET is present but its secret is not " \
+             '(no reverse shadowing)' do
+            ENV['ACCOUNT_ID_SECRET'] = 'a' * 40
+
+            expect do
+              create_roda_app do
+                enable(*order)
+                production_env_check true
+              end
+            end.to raise_error(Rodauth::ConfigurationError, cfg[:error])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb
+++ b/spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb
@@ -1,0 +1,351 @@
+# spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'rodauth'
+require 'roda'
+
+RSpec.describe 'AccountIdObfuscation' do
+  let(:db) do
+    d = Sequel.sqlite
+    d.create_table(:accounts) do
+      primary_key :id
+      String :email, null: false
+      Integer :status_id, default: 2
+    end
+    d[:accounts].insert(email: 'user@example.com', status_id: 2) # id = 1
+    d
+  end
+
+  after { db&.disconnect }
+
+  def create_roda_app(&rodauth_block)
+    test_db = db
+
+    Class.new(Roda) do
+      plugin :rodauth do
+        db test_db
+        instance_eval(&rodauth_block) if rodauth_block
+      end
+
+      route(&:rodauth)
+    end
+  end
+
+  def default_app
+    create_roda_app do
+      enable :login, :verify_account, :account_id_obfuscation
+      hmac_secret 'h' * 32
+      account_id_obfuscation_secret 'a' * 40
+      production_env_check false
+    end
+  end
+
+  def capture_warnings
+    old_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = old_stderr
+  end
+
+  describe 'enabling the feature' do
+    it 'builds an app with the feature enabled' do
+      app = default_app
+      expect(app.rodauth.features).to include(:account_id_obfuscation)
+    end
+
+    it 'auto-enables its email_base dependency' do
+      app = create_roda_app do
+        enable :account_id_obfuscation
+        account_id_obfuscation_secret 'a' * 40
+        production_env_check false
+      end
+      expect(app.rodauth.features).to include(:email_base)
+    end
+  end
+
+  describe '#obfuscate_account_id / #deobfuscate_account_id' do
+    let(:rodauth) { default_app.rodauth.allocate }
+
+    it 'round-trips an id' do
+      token = rodauth.obfuscate_account_id(1)
+      expect(rodauth.deobfuscate_account_id(token)).to eq(1)
+    end
+
+    it 'prefixes the token with the version tag and is 14 chars wide' do
+      token = rodauth.obfuscate_account_id(1)
+      expect(token).to start_with('A')
+      expect(token.length).to eq(1 + Rodauth::Tools::AccountIdCipher::WIDTH)
+    end
+
+    it 'does not leak the plaintext id' do
+      expect(rodauth.obfuscate_account_id(1)).not_to include('1')
+    end
+
+    it 'returns nil for a legacy decimal id segment' do
+      expect(rodauth.deobfuscate_account_id('1')).to be_nil
+    end
+
+    it 'returns nil for a 13-digit decimal id (the previously-ambiguous case)' do
+      expect(rodauth.deobfuscate_account_id('1234567890123')).to be_nil
+    end
+
+    it 'returns nil for nil and non-token garbage' do
+      expect(rodauth.deobfuscate_account_id(nil)).to be_nil
+      expect(rodauth.deobfuscate_account_id('not-a-token!!')).to be_nil
+    end
+
+    it 'returns nil for a token carrying an unknown version tag' do
+      token = rodauth.obfuscate_account_id(1)
+      tampered = "Z#{token[1..]}"
+      expect(rodauth.deobfuscate_account_id(tampered)).to be_nil
+    end
+  end
+
+  describe 'email link obfuscation (via real email_base)' do
+    let(:rodauth) do
+      r = default_app.rodauth.allocate
+      r.instance_variable_set(:@account, { id: 1, email: 'user@example.com', status_id: 2 })
+      r
+    end
+
+    it 'obfuscates the id segment of the outgoing token' do
+      link = rodauth.send(:token_param_value, 'rawkey')
+      segment = link.split('_', 2).first
+      expect(segment).to eq(rodauth.obfuscate_account_id(1))
+      expect(link).not_to start_with('1_')
+    end
+
+    it 'decodes an obfuscated token back to the account on consume' do
+      link = rodauth.send(:token_param_value, 'rawkey')
+      loaded = rodauth.send(:account_from_key, link) { |id| id == 1 ? 'rawkey' : nil }
+      expect(loaded[:id]).to eq(1)
+    end
+
+    it 'rejects an obfuscated token whose key does not match' do
+      link = rodauth.send(:token_param_value, 'rawkey')
+      loaded = rodauth.send(:account_from_key, link) { |_id| 'wrongkey' }
+      expect(loaded).to be_nil
+    end
+
+    it 'still resolves a legacy plaintext token (backward compatibility)' do
+      legacy = "1_#{rodauth.send(:convert_email_token_key, "rawkey")}"
+      loaded = rodauth.send(:account_from_key, legacy) { |id| id == 1 ? 'rawkey' : nil }
+      expect(loaded[:id]).to eq(1)
+    end
+
+    it 'passes a separator-less token through to base without obfuscation (no crash)' do
+      # No separator => decode step is skipped and base rejects it as malformed.
+      expect(rodauth.send(:account_from_key, 'no-separator-here') { |_id| 'x' }).to be_nil
+    end
+  end
+
+  describe 'key rotation via previous_secrets' do
+    let(:rodauth) do
+      create_roda_app do
+        enable :login, :verify_account, :account_id_obfuscation
+        hmac_secret 'h' * 32
+        account_id_obfuscation_secret 'b' * 40 # current, version 'B'
+        account_id_obfuscation_key_version 'B'
+        account_id_obfuscation_previous_secrets({ 'A' => 'a' * 40 }) # retired, version 'A'
+        production_env_check false
+      end.rodauth.allocate
+    end
+
+    it 'mints new tokens under the current version tag' do
+      expect(rodauth.obfuscate_account_id(1)).to start_with('B')
+    end
+
+    it 'still decodes a token minted under a previous secret/version' do
+      old_cipher = Rodauth::Tools::AccountIdCipher.new('a' * 40)
+      old_token = "A#{old_cipher.encode(1)}"
+      expect(rodauth.deobfuscate_account_id(old_token)).to eq(1)
+    end
+  end
+
+  describe 'key version validation' do
+    it 'raises for a digit version tag' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_key_version '1'
+          production_env_check false
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /single non-digit/)
+    end
+
+    it 'raises for a multi-character version tag' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_key_version 'AB'
+          production_env_check false
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /single non-digit/)
+    end
+
+    it 'raises for an underscore version tag' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'a' * 40
+          account_id_obfuscation_key_version '_'
+          production_env_check false
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /single non-digit/)
+    end
+  end
+
+  describe 'secret lifecycle' do
+    it 'raises in production when the secret is missing' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /ACCOUNT_ID_SECRET/)
+    end
+
+    it 'raises when the secret is present but shorter than 32 bytes' do
+      expect do
+        create_roda_app do
+          enable :account_id_obfuscation
+          account_id_obfuscation_secret 'too-short'
+          production_env_check true
+        end
+      end.to raise_error(Rodauth::ConfigurationError, /at least 32 bytes/)
+    end
+
+    it 'warns and falls back to a dev secret when missing in development' do
+      output = capture_warnings do
+        app = create_roda_app do
+          enable :account_id_obfuscation
+          production_env_check false
+        end
+        # feature still works with the fallback
+        expect(app.rodauth.allocate.obfuscate_account_id(1)).to start_with('A')
+      end
+      expect(output).to include('WARNING')
+    end
+
+    it 'loads the secret from ENV and deletes it afterwards' do
+      ENV['ACCOUNT_ID_SECRET'] = 'e' * 40
+      app = create_roda_app do
+        enable :account_id_obfuscation
+        production_env_check true
+      end
+      expect(app.rodauth.allocate.deobfuscate_account_id(app.rodauth.allocate.obfuscate_account_id(1))).to eq(1)
+      expect(ENV.fetch('ACCOUNT_ID_SECRET', nil)).to be_nil
+    ensure
+      ENV.delete('ACCOUNT_ID_SECRET')
+    end
+
+    it 'uses a custom ENV key' do
+      ENV['MY_ID_SECRET'] = 'e' * 40
+      app = create_roda_app do
+        enable :account_id_obfuscation
+        account_id_obfuscation_secret_env_key 'MY_ID_SECRET'
+        production_env_check true
+      end
+      expect(app.rodauth.allocate.obfuscate_account_id(1)).to start_with('A')
+      expect(ENV.fetch('MY_ID_SECRET', nil)).to be_nil
+    ensure
+      ENV.delete('MY_ID_SECRET')
+    end
+
+    it 'prefers an explicitly-set secret over the ENV var' do
+      ENV['ACCOUNT_ID_SECRET'] = 'e' * 40
+      app = create_roda_app do
+        enable :account_id_obfuscation
+        account_id_obfuscation_secret 'x' * 40
+        production_env_check true
+      end
+      expect(app).not_to be_nil
+      expect(ENV.fetch('ACCOUNT_ID_SECRET', nil)).to eq('e' * 40)
+    ensure
+      ENV.delete('ACCOUNT_ID_SECRET')
+    end
+
+    it 'skips validation when validate_secrets_on_configure? is false' do
+      app = create_roda_app do
+        enable :account_id_obfuscation
+        production_env_check true
+        validate_secrets_on_configure? false
+      end
+      expect(app).not_to be_nil
+    end
+  end
+
+  describe 'remember cookie obfuscation' do
+    def remember_app(obfuscate_cookie: true)
+      create_roda_app do
+        enable :login, :remember, :account_id_obfuscation
+        hmac_secret 'h' * 32
+        account_id_obfuscation_secret 'a' * 40
+        account_id_obfuscation_remember_cookie? obfuscate_cookie
+        production_env_check false
+      end
+    end
+
+    it 'installs the cookie overrides on the Auth subclass when remember is enabled' do
+      auth = remember_app.rodauth
+      expect(auth.instance_method(:_get_remember_cookie).owner).to eq(auth)
+      expect(auth.instance_method(:_set_remember_cookie).owner).to eq(auth)
+    end
+
+    it 'does not install the overrides when the toggle is off' do
+      auth = remember_app(obfuscate_cookie: false).rodauth
+      expect(auth.instance_method(:_get_remember_cookie).owner).not_to eq(auth)
+    end
+
+    it 'does not install the overrides when remember is not enabled' do
+      auth = default_app.rodauth
+      expect(auth.private_instance_methods).not_to include(:_get_remember_cookie)
+    end
+
+    it 'decodes the id segment of an obfuscated cookie on read' do
+      r = remember_app.rodauth.allocate
+      obfuscated = "#{r.obfuscate_account_id(1)}_HMAC_WITH_UNDERSCORES"
+      fake_request = Struct.new(:cookies).new({ '_remember' => obfuscated })
+      r.define_singleton_method(:request) { fake_request }
+
+      expect(r.send(:_get_remember_cookie)).to eq('1_HMAC_WITH_UNDERSCORES')
+    end
+
+    it 'passes a legacy numeric cookie through unchanged on read' do
+      r = remember_app.rodauth.allocate
+      legacy = '1_HMAC_WITH_UNDERSCORES'
+      fake_request = Struct.new(:cookies).new({ '_remember' => legacy })
+      r.define_singleton_method(:request) { fake_request }
+
+      expect(r.send(:_get_remember_cookie)).to eq(legacy)
+    end
+
+    it 'writes an obfuscated id into the cookie on set' do
+      r = remember_app.rodauth.allocate
+      headers = {}
+      r.define_singleton_method(:response) { Struct.new(:headers).new(headers) }
+      r.define_singleton_method(:request) { Struct.new(:ssl?).new(false).tap { |s| def s.ssl? = false } }
+
+      r.send(:_set_remember_cookie, 1, 'remkey', Time.now + 1000)
+      cookie_header = headers.values.join
+      expect(cookie_header).to include(r.obfuscate_account_id(1))
+      expect(cookie_header).not_to include('=1_')
+    end
+  end
+
+  describe 'non-interference with other token consumers' do
+    it 'does not override the global split_token / convert_token_id' do
+      auth = default_app.rodauth
+      # These remain owned by Rodauth's base feature, not our subclass/feature.
+      expect(auth.instance_method(:split_token).owner).not_to eq(auth)
+      expect(auth.instance_method(:convert_token_id).owner).not_to eq(auth)
+    end
+  end
+end

--- a/spec/rodauth/features/external_identity/external_identity_spec.rb
+++ b/spec/rodauth/features/external_identity/external_identity_spec.rb
@@ -877,9 +877,9 @@ RSpec.describe 'Rodauth external_identity feature' do
             external_identity_column :stripe_id
           end
         end.to raise_error(ArgumentError) do |error|
-          expect(error.message).to match(/autocreate/)
-          expect(error.message).to match(/Sequel\.migration/)
-          expect(error.message).to match(/add_column :stripe_id/)
+          expect(error.message).to include('autocreate')
+          expect(error.message).to include('Sequel.migration')
+          expect(error.message).to include('add_column :stripe_id')
         end
       end
     end

--- a/spec/rodauth/features/external_identity_autocreate_integration_spec.rb
+++ b/spec/rodauth/features/external_identity_autocreate_integration_spec.rb
@@ -356,9 +356,9 @@ RSpec.describe 'Rodauth external_identity :autocreate + table_guard sequel_mode 
           external_identity_column :stripe_customer_id
         end
       end.to raise_error(ArgumentError) do |error|
-        expect(error.message).to match(/autocreate/)
-        expect(error.message).to match(/Sequel\.migration/)
-        expect(error.message).to match(/add_column :stripe_customer_id/)
+        expect(error.message).to include('autocreate')
+        expect(error.message).to include('Sequel.migration')
+        expect(error.message).to include('add_column :stripe_customer_id')
       end
     end
 

--- a/spec/rodauth/tools/account_id_cipher_spec.rb
+++ b/spec/rodauth/tools/account_id_cipher_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe Rodauth::Tools::AccountIdCipher do
     end
   end
 
+  describe '#decode rejects non-canonical tokens (Finding #8)' do
+    it 'returns nil for a well-formed but non-canonical token (first char shifted +16 alphabet positions)' do
+      # 13 Crockford chars encode 65 bits for a 64-bit block, so the first
+      # (most-significant) char of any token +encode+ actually produces always
+      # has an alphabet index < 16 -- the top of those 5 bits is discarded by
+      # the 64-bit mask. Shifting that index up by 16 yields a second,
+      # non-canonical 13-char string that decrypts to the same id but is never
+      # itself an +encode+ output.
+      canonical = cipher.encode(2)
+      idx = described_class::ALPHABET.index(canonical[0])
+      non_canonical = "#{described_class::ALPHABET[idx + 16]}#{canonical[1..]}"
+
+      expect(non_canonical.length).to eq(described_class::WIDTH)
+      expect(non_canonical).not_to eq(canonical)
+      expect(cipher.decode(non_canonical)).to be_nil
+    end
+
+    it 'does not reject any legitimately-minted token' do
+      boundary_ids.each { |id| expect(cipher.decode(cipher.encode(id))).to eq(id) }
+    end
+  end
+
   describe 'key dependence' do
     it 'produces different ciphertext under a different secret' do
       other = described_class.new('b' * 32)

--- a/spec/rodauth/tools/account_id_cipher_spec.rb
+++ b/spec/rodauth/tools/account_id_cipher_spec.rb
@@ -1,0 +1,107 @@
+# spec/rodauth/tools/account_id_cipher_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rodauth::Tools::AccountIdCipher do
+  let(:secret) { 'a' * 32 }
+  let(:cipher) { described_class.new(secret) }
+
+  # Boundary ids across the 32-bit split point and the 64-bit domain edges.
+  let(:boundary_ids) do
+    [0, 1, 2, 3, 42, 1000, (2**31) - 1, 2**31, (2**32) - 1, 2**32,
+     2**53, 2**62, (2**63) - 1, (2**64) - 1]
+  end
+
+  describe '#initialize' do
+    it 'accepts a secret of at least 32 bytes' do
+      expect { described_class.new('a' * 32) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError for a secret shorter than 32 bytes' do
+      expect { described_class.new('a' * 31) }.to raise_error(ArgumentError, /32 bytes/)
+    end
+
+    it 'raises ArgumentError for a nil secret' do
+      expect { described_class.new(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'exposes the minimum secret length' do
+      expect(described_class::MIN_SECRET_BYTES).to eq(32)
+    end
+  end
+
+  describe '#encode / #decode round-trip' do
+    it 'round-trips every boundary id across the 64-bit domain' do
+      boundary_ids.each do |id|
+        expect(cipher.decode(cipher.encode(id))).to eq(id)
+      end
+    end
+
+    it 'coerces #to_i-style integer input' do
+      expect(cipher.decode(cipher.encode(Integer('7')))).to eq(7)
+    end
+  end
+
+  describe '#encode output format' do
+    it 'is always exactly 13 characters wide' do
+      widths = boundary_ids.map { |id| cipher.encode(id).length }.uniq
+      expect(widths).to eq([described_class::WIDTH])
+    end
+
+    it 'uses only the Crockford Base32 alphabet' do
+      allowed = described_class::ALPHABET.chars.to_set
+      boundary_ids.each do |id|
+        expect(cipher.encode(id).chars.to_set).to be_subset(allowed)
+      end
+    end
+
+    it 'never contains an underscore (URL- and cookie-separator-safe)' do
+      expect(boundary_ids.map { |id| cipher.encode(id) }.none? { |t| t.include?('_') }).to be(true)
+    end
+
+    it 'maps adjacent ids to unrelated tokens (no visible sequence)' do
+      expect(cipher.encode(2)).not_to eq(cipher.encode(3))
+      expect(cipher.encode(1000)[0, 4]).not_to eq(cipher.encode(1001)[0, 4])
+    end
+  end
+
+  describe '#encode is a bijection' do
+    it 'produces no collisions across a large contiguous range' do
+      seen = {}
+      collision = false
+      (0..20_000).each do |i|
+        token = cipher.encode(i)
+        collision ||= seen.key?(token)
+        seen[token] = i
+      end
+      expect(collision).to be(false)
+    end
+  end
+
+  describe '#decode with malformed input' do
+    [nil, '', 'too-short', 'x' * 14, '!!!!!!!!!!!!!', 12_345, :symbol].each do |bad|
+      it "returns nil for #{bad.inspect}" do
+        expect(cipher.decode(bad)).to be_nil
+      end
+    end
+
+    it 'returns nil for a 13-char string containing a non-alphabet character' do
+      # 'I', 'L', 'O', 'U' are excluded from Crockford Base32
+      expect(cipher.decode('IIIIIIIIIIIII')).to be_nil
+    end
+  end
+
+  describe 'key dependence' do
+    it 'produces different ciphertext under a different secret' do
+      other = described_class.new('b' * 32)
+      expect(cipher.encode(2)).not_to eq(other.encode(2))
+    end
+
+    it 'does not decode a token minted under a different secret back to the id' do
+      other = described_class.new('b' * 32)
+      expect(cipher.decode(other.encode(2))).not_to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `account_id_obfuscation` Rodauth feature that obfuscates numeric account IDs in email-verification links and remember-me cookies using keyed format-preserving encryption, with no database schema changes required.

### Deployment Notes

> [!IMPORTANT] 
> Adds a new env var `ACCOUNT_ID_SECRET`. Production raises `ConfigurationError` if missing.

## Key Changes

- **New Feature:** `lib/rodauth/features/account_id_obfuscation.rb`
  - Wraps `email_base` chokepoints (`token_param_value` / `account_from_key`) to obfuscate the account ID segment of email tokens
  - Optionally obfuscates the remember-me cookie when `remember` is enabled
  - Implements version-tagged tokens (single non-digit prefix) for deterministic backward compatibility and config-driven key rotation
  - Loads `ACCOUNT_ID_SECRET` from environment following the `hmac_secret_guard` pattern
  - Validates secrets at startup; raises in production if missing, warns and falls back in development

- **New Cipher Primitive:** `lib/rodauth/tools/account_id_cipher.rb`
  - Framework-agnostic 4-round Feistel network keyed with HMAC-SHA256 (format-preserving encryption)
  - Bijection over 64-bit domain: `Integer <-> 13-char Crockford Base32` token
  - No collisions, deterministic, requires secret to invert
  - Deliberately excludes underscore from alphabet to avoid collision with `token_separator`

- **Comprehensive Test Suite:** `spec/rodauth/features/account_id_obfuscation/account_id_obfuscation_spec.rb`
  - 351 lines covering feature enablement, obfuscation/deobfuscation round-trips, email link obfuscation, key rotation, secret lifecycle, remember cookie obfuscation, and backward compatibility
  - Tests legacy plaintext token passthrough, version tag validation, and non-interference with other token consumers

- **Cipher Unit Tests:** `spec/rodauth/tools/account_id_cipher_spec.rb`
  - 107 lines testing boundary ids, bijection property, output format, malformed input handling, and key dependence

- **Documentation:** `docs/features/account-id-obfuscation.md`
  - 297 lines covering how it works, configuration options, usage examples, backward compatibility guarantees, key rotation, security notes, and testing guidance

- **Supporting Changes:**
  - Updated `README.md` with feature overview and key characteristics
  - Updated `CHANGELOG.md` with v0.4.0 release notes
  - Updated `CLAUDE.md` project description
  - Updated `lib/rodauth/tools.rb` to require the new cipher
  - Bumped version to 0.4.0 in `lib/rodauth/tools/version.rb`
  - Added documentation exclusion to `.rubocop_todo.yml`

## Implementation Details

**Backward Compatibility:** The version tag (single non-digit character, default `'A'`) makes obfuscated tokens deterministically distinguishable from legacy decimal IDs. Legacy links/cookies deobfuscate to `nil` and pass through unchanged, so in-flight numeric tokens continue to work during and after rollout.

**Scoped Overrides:** Deliberately wraps only the two `email_base` chokepoints, leaving `split_token`/`convert_token_id` untouched. This ensures other token consumers (e.g., `jwt_refresh`) are unaffected and `internal_request` delegates through the override cleanly.

**Secret Lifecycle:** Follows the `hmac_secret_guard` pattern—loads from `ACCOUNT_ID_SECRET` environment variable (configurable), deletes it after loading, validates at startup, and requires >= 32 bytes. Production raises `ConfigurationError` if missing; development warns and uses a fallback.

**Key Rotation:** Version-tagged tokens enable config-driven rotation via `account_id_obfuscation_previous_secrets` map. New tokens mint under the current version; outstanding old-version tokens still decode using their retired secrets.

https://claude.ai/code/session_01Cruz3Njr2vUUn8QeiZMSep