### PR TITLE
Copilot follow-ups: clearer minimum-length error and validation-override docs

### DIFF
--- a/docs/features/hmac-secret-guard.md
+++ b/docs/features/hmac-secret-guard.md
@@ -623,9 +623,11 @@ A minimum length is available out of the box via `minimum_secret_length`
 (production only). For anything beyond that, override the kind-specific
 `validate_hmac_secret!` method in your configuration.
 
-> **Note:** `validate_hmac_secret!` does not accept a block. Override the method
-> (not `validate_secrets!`, which is a shared alias) so it keeps working when
-> `jwt_secret_guard` is also enabled.
+> **Note:** `validate_hmac_secret!` does not take a block when *called* at
+> runtime. To customize validation, *override* the method in your configuration
+> (the block form shown below is the Rodauth config-DSL override, not a runtime
+> call). Override `validate_hmac_secret!` — not `validate_secrets!`, which is a
+> shared alias — so it keeps working when `jwt_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do

--- a/docs/features/jwt-secret-guard.md
+++ b/docs/features/jwt-secret-guard.md
@@ -622,9 +622,11 @@ A minimum length is available out of the box via `minimum_secret_length`
 (production only). For anything beyond that, override the kind-specific
 `validate_jwt_secret!` method in your configuration.
 
-> **Note:** `validate_jwt_secret!` does not accept a block. Override the method
-> (not `validate_secrets!`, which is a shared alias) so it keeps working when
-> `hmac_secret_guard` is also enabled.
+> **Note:** `validate_jwt_secret!` does not take a block when *called* at
+> runtime. To customize validation, *override* the method in your configuration
+> (the block form shown below is the Rodauth config-DSL override, not a runtime
+> call). Override `validate_jwt_secret!` — not `validate_secrets!`, which is a
+> shared alias — so it keeps working when `hmac_secret_guard` is also enabled.
 
 ```ruby
 plugin :rodauth do

--- a/lib/rodauth/secret_guard.rb
+++ b/lib/rodauth/secret_guard.rb
@@ -97,8 +97,14 @@ module Rodauth
       return unless rodauth.production?
       return if value.to_s.strip.length >= minimum
 
+      # Name the secret generically and cite both configuration avenues: the
+      # value may have come from the env var OR from the #{kind}_secret DSL
+      # method, so blaming the env key alone would mislead when a short secret
+      # was configured directly.
+      key = rodauth.send(:"#{kind}_secret_env_key")
       raise Rodauth::ConfigurationError,
-            "#{rodauth.send(:"#{kind}_secret_env_key")} must be at least #{minimum} characters in production"
+            "#{kind.to_s.upcase} secret must be at least #{minimum} characters in production " \
+            "(set via #{key} or #{kind}_secret)"
     end
 
     # @return [Boolean] true when the value is nil, empty, or whitespace-only


### PR DESCRIPTION
Follow-up to the merged #118, addressing the remaining Copilot review comments that landed after #118 was merged. Targets the security-audit branch (#117).

Single commit, three files.

## Changes

**`lib/rodauth/secret_guard.rb` — clearer minimum-length error (Copilot: Medium)**
The `minimum_secret_length` error always named the environment variable key (e.g. `"JWT_SECRET must be at least 32 characters…"`) even when the short secret was configured directly via the `jwt_secret` / `hmac_secret` DSL, which misled debugging. It now names the secret generically and cites both configuration avenues:

> `JWT secret must be at least 32 characters in production (set via JWT_SECRET or jwt_secret)`

The message still contains `at least N`, so the existing `/at least 32/` specs continue to pass.

**`docs/features/{hmac,jwt}-secret-guard.md` — validation-override note (Copilot: Low ×2)**
The note read `validate_*_secret! does not accept a block`, which contradicted the config-DSL override example (a block) shown immediately below it. Reworded to clarify the no-block rule applies when *calling* the method at runtime, while the block form shown is the Rodauth config-DSL **override**.

## Testing
- Full suite: **236 examples, 0 failures**.
- RuboCop: `secret_guard.rb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKtf35vgWVQhbYVhVX2x1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtf35vgWVQhbYVhVX2x1e)_