### PR TITLE
Clear pre-existing RuboCop debt (stacked on #119)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
+Style/OneClassPerFile:
+  Exclude:
+    - 'examples/**/*'
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/lib/rodauth/table_inspector.rb
+++ b/lib/rodauth/table_inspector.rb
@@ -97,7 +97,7 @@ module Rodauth
         next unless feature_module
 
         # Check if this feature module defines the table method
-        return feature_name if feature_module.instance_methods(false).include?(method_name)
+        return feature_name if feature_module.method_defined?(method_name, false)
       end
 
       # Fallback: try to infer from method name if not found in any feature

--- a/lib/rodauth/tools/migration.rb
+++ b/lib/rodauth/tools/migration.rb
@@ -158,8 +158,9 @@ module Rodauth
       #
       # PostgreSQL: Use native jsonb type for efficient JSON storage and querying
       # MySQL: Use native json type (supported since MySQL 5.7.8)
-      # SQLite: Use String type - SQLite stores JSON as text, but has JSON1 extension
-      #         for querying. Sequel doesn't have a :json type for SQLite.
+      # SQLite: Use String type (via the fallback below) - SQLite stores JSON as
+      #         text, but has JSON1 extension for querying. Sequel doesn't have
+      #         a :json type for SQLite.
       # Other: Fall back to String for maximum compatibility
       def json_type
         case db.database_type
@@ -167,8 +168,6 @@ module Rodauth
           ':jsonb'
         when :mysql
           ':json'
-        when :sqlite
-          String
         else
           String
         end

--- a/spec/rodauth/features/external_identity/external_identity_spec.rb
+++ b/spec/rodauth/features/external_identity/external_identity_spec.rb
@@ -877,9 +877,9 @@ RSpec.describe 'Rodauth external_identity feature' do
             external_identity_column :stripe_id
           end
         end.to raise_error(ArgumentError) do |error|
-          expect(error.message).to match(/autocreate/)
-          expect(error.message).to match(/Sequel\.migration/)
-          expect(error.message).to match(/add_column :stripe_id/)
+          expect(error.message).to include('autocreate')
+          expect(error.message).to include('Sequel.migration')
+          expect(error.message).to include('add_column :stripe_id')
         end
       end
     end

--- a/spec/rodauth/features/external_identity_autocreate_integration_spec.rb
+++ b/spec/rodauth/features/external_identity_autocreate_integration_spec.rb
@@ -356,9 +356,9 @@ RSpec.describe 'Rodauth external_identity :autocreate + table_guard sequel_mode 
           external_identity_column :stripe_customer_id
         end
       end.to raise_error(ArgumentError) do |error|
-        expect(error.message).to match(/autocreate/)
-        expect(error.message).to match(/Sequel\.migration/)
-        expect(error.message).to match(/add_column :stripe_customer_id/)
+        expect(error.message).to include('autocreate')
+        expect(error.message).to include('Sequel.migration')
+        expect(error.message).to include('add_column :stripe_customer_id')
       end
     end
 


### PR DESCRIPTION
Stacked on #119 (`claude/rodauth-obfuscate-account-id-lyvz9k`). Once #119 merges, retarget this PR to `main` — the single commit here (`d615cb1`) contains only the cleanup.

Fixes the nine RuboCop offenses that predate #119 (they live in files that PR never touched), so the repo lints clean end to end. **Zero behavior change.**

## Changes

| Offense | Fix |
|---|---|
| `RSpec/MatchWithSimpleRegex` ×6 — `external_identity_spec.rb:880-882`, `external_identity_autocreate_integration_spec.rb:359-361` | `match(/literal/)` → `include('literal')`. Every regex was a pure literal; the one escaped dot (`Sequel\.migration`) makes the string form exactly equivalent. |
| `Style/ModuleMemberExistenceCheck` — `table_inspector.rb:100` | `instance_methods(false).include?(m)` → `method_defined?(m, false)`. Same public+protected / no-ancestors semantics, without the intermediate array (`required_ruby_version >= 3.2` covers the two-arg form). |
| `Lint/DuplicateBranch` — `migration.rb` `json_type` | Merged the duplicate `when :sqlite` / `else` branches (both returned `String`); SQLite's return value is unchanged and the comment still documents why. |
| `Style/OneClassPerFile` — `examples/sinatra-table-guard/app.rb` | Excluded `examples/**/*` in `.rubocop.yml` — a single-file demo app legitimately defines its Roda and Sinatra classes together. No inline disables. |

## Verification

- Full suite: **309 examples, 0 failures**
- RuboCop: **40 files inspected, no offenses detected** (was 9 offenses / 7 autocorrectable)
- Diff touches only the 5 files above — the secret-guard files, `account_id_obfuscation.rb`, and `account_id_cipher.rb` are untouched
- An independent adversarial review pass over the diff was run in addition to the checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKtf35vgWVQhbYVhVX2x1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtf35vgWVQhbYVhVX2x1e)_