### PR TITLE
Fix :recreate/:drop to include hidden tables and run atomically 

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 524
+  Max: 532
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
@@ -64,12 +64,12 @@ Metrics/CyclomaticComplexity:
 # Offense count: 41
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 64
+  Max: 69
 
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 526
+  Max: 534
 
 # Offense count: 10
 # Configuration parameters: AllowedMethods, AllowedPatterns.
@@ -109,6 +109,7 @@ RSpec/DescribeClass:
     - 'spec/rodauth/features/external_identity/external_identity_spec.rb'
     - 'spec/rodauth/features/external_identity_autocreate_integration_spec.rb'
     - 'spec/rodauth/features/secret_guard_combined_spec.rb'
+    - 'spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_integration_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_spec.rb'
@@ -207,6 +208,7 @@ Style/SafeNavigation:
     - 'spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb'
     - 'spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb'
     - 'spec/rodauth/features/secret_guard_combined_spec.rb'
+    - 'spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
 
 # Offense count: 1
@@ -235,6 +237,7 @@ Style/SymbolProc:
     - 'spec/rodauth/features/hmac_secret_guard/hmac_secret_guard_spec.rb'
     - 'spec/rodauth/features/jwt_secret_guard/jwt_secret_guard_spec.rb'
     - 'spec/rodauth/features/secret_guard_combined_spec.rb'
+    - 'spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_integration_spec.rb'
     - 'spec/rodauth/features/table_guard/table_guard_simple_spec.rb'
     - 'try/features/external_identity_try.rb'

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -700,22 +700,38 @@ module Rodauth
           return
         end
 
-        # Get all required tables from configuration
-        all_tables = table_configuration.map { |_, info| info[:name] }.uniq
+        # Enumerate every table the enabled features' ERB templates create —
+        # including "hidden" tables such as account_statuses and
+        # account_password_hashes that have no *_table method (RT-09) — and drop
+        # them in FK-dependency order via the generator (the same path :sync
+        # already uses). The previous code dropped only the discovered *_table
+        # names in reversed hash order, so it left the hidden tables in place and
+        # the recreate step then failed with "table account_statuses already
+        # exists", making :recreate unusable with the default schema.
+        features = enabled_template_features
 
-        # Drop all existing tables in reverse dependency order
-        rodauth_info("[table_guard] Recreating #{all_tables.size} table(s) (dropping all, creating fresh)...")
-        drop_tables(all_tables.reverse)
+        rodauth_info("[table_guard] Recreating tables for #{features.size} feature(s) " \
+                     '(dropping all, creating fresh)...')
 
-        # Create all tables fresh (uses missing_tables which should now be all of them)
-        current_missing = missing_tables
-        current_missing_cols = missing_columns
-        if current_missing.any? || current_missing_cols.any?
-          generator_for_all = Rodauth::SequelGenerator.new(current_missing, self, current_missing_cols)
-          generator_for_all.execute_creates(db)
+        # Wrap the whole drop+create cycle in one transaction so a failure
+        # part-way through cannot leave a partially dropped schema (RT-08).
+        # Transactional DDL is a no-op on MySQL (it auto-commits DDL), but it
+        # makes PostgreSQL and SQLite atomic, which is exactly where an
+        # out-of-order drop would otherwise destroy data and then fail.
+        db.transaction do
+          generator.execute_drops(db, features: features)
+
+          # Every required table is now missing, so recreate them all from the
+          # templates (base.erb brings back the hidden tables too).
+          current_missing = missing_tables
+          current_missing_cols = missing_columns
+          if current_missing.any? || current_missing_cols.any?
+            generator_for_all = Rodauth::SequelGenerator.new(current_missing, self, current_missing_cols)
+            generator_for_all.execute_creates(db)
+          end
         end
 
-        rodauth_info("[table_guard] Recreated #{all_tables.size} table(s)")
+        rodauth_info("[table_guard] Recreated tables for #{features.size} feature(s)")
 
         # Re-validate to show success message
         revalidate_after_creation
@@ -730,17 +746,24 @@ module Rodauth
           return
         end
 
-        # Get all required tables from configuration
-        all_tables = table_configuration.map { |_, info| info[:name] }.uniq
+        # Drop every table the enabled features' templates create, hidden
+        # tables included (RT-09), in FK-dependency order via the generator.
+        features = enabled_template_features
 
-        # Drop all existing tables in reverse dependency order
-        rodauth_info("[table_guard] Dropping #{all_tables.size} table(s)...")
-        drop_tables(all_tables.reverse)
+        rodauth_info("[table_guard] Dropping tables for #{features.size} feature(s)...")
 
-        # Drop Sequel migration tracking tables so migrations re-run from scratch
-        drop_tables(%i[schema_info schema_migrations])
+        # One transaction for the whole drop so it is atomic (RT-08).
+        db.transaction do
+          generator.execute_drops(db, features: features)
 
-        rodauth_info("[table_guard] Dropped #{all_tables.size} table(s) and migration tracking")
+          # Drop Sequel migration tracking tables so migrations re-run from
+          # scratch. These are independent leaf tables with no ordering
+          # constraints, so the simple helper is fine; keeping them in the same
+          # transaction makes the whole :drop atomic.
+          drop_tables(%i[schema_info schema_migrations])
+        end
+
+        rodauth_info("[table_guard] Dropped tables for #{features.size} feature(s) and migration tracking")
         rodauth_info('[table_guard] Migrations will run from scratch on next execution')
 
       else
@@ -762,13 +785,37 @@ module Rodauth
       %i[postgres mysql].include?(db.database_type)
     end
 
-    # Drop tables with proper CASCADE handling for non-SQLite databases
+    # Feature names (matching ERB template basenames) for every discovered
+    # required table, de-duplicated.
     #
-    # SQLite doesn't support CASCADE on DROP TABLE, so we need to detect
-    # the database type and avoid using it. For other databases, CASCADE
-    # ensures dependent objects are properly cleaned up.
+    # Used by :recreate/:drop to enumerate the full set of tables to drop from
+    # the templates — including hidden tables like account_statuses — rather
+    # than only the discovered *_table names. A feature whose template is
+    # missing simply contributes no tables (TemplateInspector returns [] for
+    # it), which is consistent with the create path, which likewise cannot
+    # build a table it has no template for.
     #
-    # @param table_names [Array<String, Symbol>] Tables to drop
+    # @return [Array<Symbol>] Enabled feature names that own required tables
+    def enabled_template_features
+      table_configuration.map { |_, info| info[:feature] }.compact.uniq
+    end
+
+    # Drop a set of independent tables (no inter-table foreign keys), with
+    # CASCADE where the adapter supports it.
+    #
+    # This helper does NOT order for foreign-key dependencies. The destructive
+    # sequel modes route their FK-ordered drops through
+    # SequelGenerator#execute_drops, which enumerates the templates (hidden
+    # tables included) and drops child-before-parent. This helper is now used
+    # only for the Sequel migration-tracking tables (:schema_info,
+    # :schema_migrations) in :drop mode, which have no ordering constraints. It
+    # opens no transaction of its own, so a caller can wrap it (together with
+    # execute_drops) in a single transaction for atomicity (RT-08).
+    #
+    # SQLite doesn't support CASCADE on DROP TABLE, so we detect the database
+    # type and avoid it there.
+    #
+    # @param table_names [Array<String, Symbol>] Independent tables to drop
     def drop_tables(table_names)
       table_names.each do |table_name|
         next unless db.table_exists?(table_name)

--- a/lib/rodauth/sequel_generator.rb
+++ b/lib/rodauth/sequel_generator.rb
@@ -263,12 +263,22 @@ module Rodauth
 
     # Execute DROP TABLE operations directly against the database
     #
-    # Uses TemplateInspector to extract ALL tables from ERB templates.
+    # Uses TemplateInspector to extract ALL tables from ERB templates,
+    # including "hidden" tables (account_statuses, account_password_hashes)
+    # that have no corresponding *_table method.
+    #
+    # By default the feature set is derived from missing_tables (the :sync
+    # path). Callers that need to drop the full schema regardless of what is
+    # currently missing — :recreate and :drop, where nothing may be "missing" —
+    # pass an explicit +features+ list so the template enumeration still covers
+    # every enabled feature (and therefore the hidden tables).
     #
     # @param db [Sequel::Database] Database connection
-    def execute_drops(db)
+    # @param features [Array<Symbol>, nil] Explicit feature list to enumerate;
+    #   when nil, features are inferred from missing_tables
+    def execute_drops(db, features: nil)
       # Extract all tables from ERB templates
-      all_tables = extract_all_tables_from_templates
+      all_tables = extract_all_tables_from_templates(features: features)
 
       # Drop in reverse order to handle foreign key dependencies
       ordered_tables = order_tables_for_drop(all_tables).reverse
@@ -336,9 +346,11 @@ module Rodauth
     # like account_statuses and account_password_hashes that don't have
     # corresponding *_table methods in Rodauth.
     #
+    # @param features [Array<Symbol>, nil] Explicit feature list; when nil,
+    #   features are inferred from missing_tables (the :sync/codegen default)
     # @return [Array<Symbol>] Array of all table names
-    def extract_all_tables_from_templates
-      features = extract_features_from_missing_tables
+    def extract_all_tables_from_templates(features: nil)
+      features ||= extract_features_from_missing_tables
       table_prefix = extract_table_prefix
       db_type = extract_db_type
 

--- a/spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb
+++ b/spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb
@@ -1,0 +1,132 @@
+# spec/rodauth/features/table_guard/table_guard_destructive_modes_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'rodauth'
+require 'roda'
+require 'logger'
+require 'stringio'
+
+# Regressions for the destructive sequel modes.
+#
+# RT-09: :recreate and :drop must operate on the FULL template-derived schema,
+#   including the "hidden" tables (account_statuses, account_password_hashes)
+#   that have no *_table method. The old code enumerated only the discovered
+#   *_table names, so it left the hidden tables in place — which made :recreate
+#   crash with "table account_statuses already exists" on the default schema.
+#
+# RT-08: the drop must run in FK-dependency order inside a single transaction,
+#   so a failure part-way through cannot leave a partially dropped schema.
+RSpec.describe 'TableGuard destructive sequel modes' do
+  let(:db) { Sequel.sqlite }
+
+  after do
+    db.disconnect if db
+  end
+
+  # :recreate/:drop only run in dev/test — force the environment per-example
+  # and restore whatever was there before.
+  around do |example|
+    previous = ENV.fetch('RACK_ENV', nil)
+    ENV['RACK_ENV'] = 'test'
+    example.run
+  ensure
+    if previous.nil?
+      ENV.delete('RACK_ENV')
+    else
+      ENV['RACK_ENV'] = previous
+    end
+  end
+
+  # A logger that swallows output, so the create/recreate info banners don't
+  # spam the test run. We assert on db state, not on log text.
+  def null_logger
+    Logger.new(StringIO.new)
+  end
+
+  def boot_app(sequel_mode:, mode: :silent)
+    test_db = db
+    quiet = null_logger
+
+    Class.new(Roda) do
+      plugin :rodauth do
+        db test_db
+        enable :login, :logout
+        enable :table_guard
+        table_guard_logger quiet
+        table_guard_mode mode
+        table_guard_sequel_mode sequel_mode
+      end
+
+      route { |r| r.rodauth }
+    end
+  end
+
+  # Build the real base schema (accounts + both hidden tables) via the
+  # generator's own :create path, so the fixture matches the templates exactly.
+  def create_full_schema!
+    boot_app(sequel_mode: :create)
+    present = db.tables
+    missing = %i[accounts account_statuses account_password_hashes].reject { |t| present.include?(t) }
+    raise "fixture setup failed, missing: #{missing.inspect} (have #{present.inspect})" unless missing.empty?
+  end
+
+  describe ':recreate' do
+    it 'recreates the full schema, hidden tables included, when tables pre-exist (RT-09)' do
+      create_full_schema!
+      expect(db.tables).to include(:account_statuses, :account_password_hashes, :accounts)
+
+      expect { boot_app(sequel_mode: :recreate) }.not_to raise_error
+
+      # Every table — the hidden ones too — is present again afterwards.
+      expect(db.tables).to include(:account_statuses, :account_password_hashes, :accounts)
+    end
+
+    it 'does not fail with "already exists" on the hidden status table (RT-09)' do
+      create_full_schema!
+
+      # With the bug the hidden account_statuses is never dropped, so re-running
+      # base.erb raises "table account_statuses already exists". In :raise mode
+      # that error is re-raised by handle_sequel_generation's rescue, so a green
+      # boot proves the hidden table was dropped before the recreate.
+      expect { boot_app(sequel_mode: :recreate, mode: :raise) }.not_to raise_error
+      expect(db.table_exists?(:accounts)).to be true
+      expect(db.table_exists?(:account_statuses)).to be true
+    end
+
+    it 'rolls the whole drop+create back on a mid-drop failure (RT-08)' do
+      create_full_schema!
+      before = db.tables.sort
+
+      # Fail on the second drop to simulate an interruption part-way through.
+      call_count = 0
+      allow(db).to receive(:drop_table?).and_wrap_original do |original, *args, **kwargs|
+        call_count += 1
+        raise Sequel::DatabaseError, 'simulated mid-drop failure' if call_count == 2
+
+        original.call(*args, **kwargs)
+      end
+
+      # Silent mode swallows the error in the rescue; the point is that the
+      # transaction must leave the schema exactly as it was.
+      boot_app(sequel_mode: :recreate)
+
+      expect(db.tables.sort).to eq(before)
+    end
+  end
+
+  describe ':drop' do
+    it 'drops every rodauth table including the hidden ones (RT-09)' do
+      create_full_schema!
+      expect(db.tables).to include(:account_statuses, :account_password_hashes, :accounts)
+
+      boot_app(sequel_mode: :drop)
+
+      expect(db.tables).not_to include(:accounts)
+      expect(db.tables).not_to include(:account_password_hashes)
+      expect(db.tables).not_to include(:account_statuses)
+    end
+  end
+end


### PR DESCRIPTION
(RT-08, RT-09)

table_guard's :recreate and :drop sequel modes built their drop list from the discovered *_table methods (table_configuration), which omits the "hidden" tables base.erb creates without a *_table method — account_statuses and account_password_hashes. :recreate therefore dropped accounts but left the hidden tables, so re-running base.erb failed with "table account_statuses already exists", making the mode unusable on the default schema (RT-09). The drops also ran in reversed hash-insertion order with no transaction, so on SQLite a mis-ordered drop could raise mid-loop and leave a partially dropped schema (RT-08).

Both modes now route their drops through SequelGenerator#execute_drops, which enumerates every table from the ERB templates (hidden ones included) and drops child-before-parent. execute_drops gains a `features:` keyword so :recreate and :drop can enumerate the enabled features even when nothing is "missing"; the default (nil) preserves the :sync/codegen behavior of inferring features from missing_tables. The whole drop+create cycle is wrapped in one transaction for atomicity — a no-op on MySQL's auto-committing DDL, but making PostgreSQL and SQLite roll back cleanly on a mid-operation failure.

The private drop_tables helper is retained only for the independent migration- tracking tables (schema_info, schema_migrations) in :drop mode and documented as not FK-ordering.

Adds regression specs covering :recreate over a pre-existing full schema, :drop removing hidden tables, and transactional rollback on a mid-drop failure. Bumps the grandfathered Metrics maxima in .rubocop_todo.yml for the few lines this adds to table_guard.rb.


Claude-Session: https://claude.ai/code/session_01FAfWDXizSbTob4ovbfTgUB