### PR TITLE
Fix table_guard backing-method visibility for rodauth 2.45.0 (v0.4.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to coding agents working in this repository.
 
 ## Project Purpose
 
@@ -11,15 +11,21 @@ Framework-agnostic utilities for Rodauth authentication:
 
 **Not a framework adapter.** For Rails integration, use rodauth-rails. This project demonstrates Rodauth's extensibility and provides reference implementations.
 
-**Status:** Experimental learning project. Not published to RubyGems.
+**Status:** Experimental. The gemspec says it plainly — "experimental stuff that may come and go" — so treat the API as unstable. It *is* published to RubyGems (`rodauth-tools`), and at least one production app depends on it, so a breaking change is a real cost to someone: bump the version and write the CHANGELOG entry.
 
-**Recent Refactoring (2025-10):** Namespace changed from `Rodauth::Rack::Generators::Migration` to `Rodauth::Tools::Migration`. This reflects the project's evolution away from being a Rack adapter toward being a collection of framework-agnostic utilities. The migration generator is now deprecated in favor of the `table_guard` feature with `sequel_mode`.
+**Namespace history (2025-10):** Namespace changed from `Rodauth::Rack::Generators::Migration` to `Rodauth::Tools::Migration`. This reflects the project's evolution away from being a Rack adapter toward being a collection of framework-agnostic utilities. The migration generator is now deprecated in favor of the `table_guard` feature with `sequel_mode`.
 
 ## Development Commands
 
 ```bash
 # Run all tests
-bundle exec rspec
+bundle exec rspec        # or: bundle exec rake
+
+# Tryouts suite (documentation-style tests; auto-discovers try/, NOT run by CI)
+bundle exec try
+
+# Lint (config in .rubocop.yml, with .rubocop_todo.yml exclusions)
+bundle exec rubocop lib/ spec/
 
 # Interactive console with helpers
 bin/console
@@ -36,6 +42,14 @@ bin/console
 - Provides introspection methods: `missing_tables`, `table_status`, `list_all_required_tables`
 - Configurable modes: `:warn`, `:error`, `:silent`, or custom block handler
 - Demonstrates proper feature lifecycle hooks and configuration DSL
+
+**lib/rodauth/features/external_identity.rb** - External Rodauth feature
+
+- Uses `Rodauth::Feature.define(:external_identity, :ExternalIdentity)` pattern
+- Declares `accounts` columns holding IDs from external services (`external_identity_column :stripe_customer_id`) and generates a reader per column
+- Layer 1 is the bare column plus conflict policy (`external_identity_on_conflict`: `:error`, `:warn`, `:skip`) and column presence checking (`external_identity_check_columns`: `true`, `false`, `:autocreate`)
+- Layer 2 hangs lifecycle callables off the same declaration: `before_create_account`, `formatter`, `validator`, `verifier`, `handshake`
+- Introspection: `external_identity_column_list`, `external_identity_column_config`, `external_identity_status`
 
 **lib/rodauth/features/hmac_secret_guard.rb** - External Rodauth feature
 
@@ -72,6 +86,7 @@ bin/console
 - Keyed format-preserving obfuscation of a 64-bit integer id (4-round Feistel network, HMAC-SHA256 round function)
 - Pure `Integer <-> 13-char Crockford Base32` bijection; stdlib `openssl` only, independently testable
 - `decode` returns `nil` on malformed input so callers can pass legacy/foreign values through
+
 **lib/rodauth/secret_guard.rb** - Shared support module (`Rodauth::SecretGuard`)
 
 - Kind-parameterized (`:hmac`/`:jwt`) logic behind both secret-guard features
@@ -80,6 +95,12 @@ bin/console
   other (each feature's `post_configure` validates its own secret via `kind`)
 - Handles ENV loading (`load_from_env!`), validation (`validate!`), blank/whitespace
   detection, production detection, and minimum-length enforcement
+
+**lib/rodauth/table_inspector.rb** - Shared support module (`Rodauth::TableInspector`)
+
+- Discovers the tables an enabled feature set requires by inspecting a live Rodauth instance, rather than from a static table
+- `discover_tables(rodauth)` returns `{ accounts_table: "accounts", ... }`; `table_information(rodauth)` adds the owning feature and column list per table
+- This is what backs `table_guard`'s `_table_configuration`, so it is the source of the `*_table` method enumeration described under Hidden Tables below
 
 **lib/rodauth/tools/migration.rb** - Sequel migration generator
 
@@ -131,7 +152,12 @@ end
 
 **Existence Checks (no logger suppression):** The `table_exists?` method matches names against the database's table/view list (`db.tables` + `db.views`) rather than probing each table with a SELECT. An earlier implementation used Sequel's `table_exists?` probe and suppressed the logger around it (clearing/restoring the shared `db.loggers` array) to hide the "no such table" ERROR that Sequel logs before catching internally — but that mutation of shared connection state was not thread-safe. Listing names avoids the failed probe entirely, so no logger suppression (and no shared-state mutation) is needed. Schema-qualified identifiers (a `Sequel::SQL::QualifiedIdentifier` or a `:schema__table` Symbol) are not present in the unqualified list, so they take a separate schema-aware `db.table_exists?` probe path.
 
-**Cached-Method Backing Visibility:** `auth_cached_method :foo` registers `foo` via `auth_private_methods`, so the backing `_foo` must be defined **private**. Rodauth 2.45.0 audits this at feature-definition time with `private_method_defined?` and warns (`RODAUTH3: raise instead of warn`) when it isn't — a publicly-defined `_foo` trips the audit even though it exists. `_table_configuration` and `_column_requirements` therefore live below the feature's `private` keyword, alongside the equivalent backing methods in `account_id_obfuscation` and `external_identity`. `spec/rodauth/feature_configuration_spec.rb` mirrors that audit across every feature this gem defines.
+**Cached-Method Backing Visibility:** `auth_cached_method :foo` registers `foo` via `auth_private_methods`, so the backing `_foo` must be defined **private**. Rodauth 2.45.0 audits this at feature-definition time with `private_method_defined?` and warns (`RODAUTH3: raise instead of warn`) when it isn't — a publicly-defined `_foo` trips the audit even though it exists. `_table_configuration` and `_column_requirements` therefore live below the feature's `private` keyword, alongside the equivalent backing methods in `account_id_obfuscation` and `external_identity`.
+
+`spec/rodauth/feature_configuration_spec.rb` holds the line. Two things about it are load-bearing, so preserve them when editing:
+
+- It **derives** its feature list from `lib/rodauth/features/*.rb` and requires each file. A hardcoded list would leave a new feature silently uncovered — and the require is what makes the audit run at all, since rodauth audits inside `Feature.define` and never sees a feature nothing loaded.
+- Per feature it **re-runs rodauth's own** `def_configuration_methods` with stderr captured and asserts silence, as well as mirroring what that method checks. The re-run cannot drift as upstream tightens the audit and honours `allowed_undefined_configuration_methods` (rodauth's opt-out) for free; the mirrored checks are what name the offending method when it fails.
 
 **Configuration Storage:** Uses instance variables set by `auth_value_method`:
 
@@ -234,9 +260,12 @@ Before TemplateInspector, `generate_drop_statements` only dropped dynamically di
 
 **RSpec Structure:**
 
-- `spec/spec_helper.rb` - Minimal configuration, loads `rodauth/rack`
+- `spec/spec_helper.rb` - Minimal configuration; requires `rodauth/tools` and `rack/test`. It does **not** require `hmac_secret_guard` or `jwt_secret_guard` — those feature files are not loaded by `rodauth/tools`, so a spec that needs them must require them itself
 - Feature specs test both behavior and configuration
 - Migration generator specs verify template output and configuration
+- `spec/rodauth/feature_configuration_spec.rb` - Guards every feature against rodauth's definition-time audit (see Cached-Method Backing Visibility above)
+
+**Tryouts:** `try/features/*_try.rb` holds documentation-style tests, run separately from RSpec (`bundle exec try`). Only `external_identity` has one today. CI runs `bundle exec rake`, whose default task is `spec` alone — so **tryouts is not gated**, and it has drifted red: 5 of 50 fail as of 0.4.1. Don't read a red tryouts run as damage you just caused; check against the base branch first.
 
 **Console Helpers:**
 
@@ -248,16 +277,17 @@ Before TemplateInspector, `generate_drop_statements` only dropped dynamically di
 
 **docs/rodauth-features-api.md** - Complete reference for feature development DSL methods
 
-**docs/rodauth-internals.rdoc** - Object model explanation:
+**docs/rodauth-integration.md** - Integrating Rodauth into a Rack app, and where this library fits
 
-- `Rodauth::Auth` - Authentication class (where features mix in)
-- `Rodauth::Configuration` - Configuration DSL class
-- `Rodauth::Feature` - Module subclass for feature definitions
-- `Rodauth::FeatureConfiguration` - Configuration module for features
+**docs/sequel-migrations.md** - Migration generator usage
 
 **docs/rodauth-mail.md** - Email/SMTP configuration patterns
 
-**DEVELOPMENT.md** - Architectural decisions, standard Rack integration pattern
+**docs/unresolved-bugs.md** - Known defects with analysis, not yet fixed. Read before "fixing" something surprising — it may already be written up here, with the reasoning for why it was left alone
+
+**docs/features/** and **docs/examples/** - Per-feature documentation and runnable examples
+
+Rodauth's own object model (`Rodauth::Auth`, `Rodauth::Configuration`, `Rodauth::Feature`, `Rodauth::FeatureConfiguration`) is documented upstream in `doc/guides/internals.rdoc` in the rodauth gem.
 
 ## Integration Pattern
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.1] - 2026-08-10
 
 ### Fixed
 
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RODAUTH3: raise instead of warn`, so this would have become a load-time error.
   Added `spec/rodauth/feature_configuration_spec.rb`, which mirrors rodauth's
   audit across all five features so a regression fails the suite.
+
+### Added
+
+- **Feature-definition audit coverage** (`spec/rodauth/feature_configuration_spec.rb`).
+  The feature list is derived from `lib/rodauth/features/*.rb` rather than
+  hand-maintained, so a newly added feature is covered as soon as its file lands
+  — and requiring those files is what makes the audit run at all, since rodauth
+  audits inside `Feature.define` and never sees a feature nothing requires.
+  Alongside the mirrored checks, each feature re-runs rodauth's own
+  `def_configuration_methods` with stderr captured and asserts it is silent, so
+  the coverage cannot drift as upstream tightens the audit and honours
+  `allowed_undefined_configuration_methods` (2.45.0's opt-out) without
+  reimplementing it.
 
 ## [0.4.0] - 2026-07-05
 
@@ -116,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Namespace changed from `Rodauth::Rack::Generators::Migration` to `Rodauth::Tools::Migration`
 - Evolution from Rack adapter to framework-agnostic utilities
 
+[0.4.1]: https://github.com/delano/rodauth-tools/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/delano/rodauth-tools/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/delano/rodauth-tools/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/delano/rodauth-tools/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`table_guard`: silence rodauth 2.45.0 feature-definition warnings.**
+  `_table_configuration` and `_column_requirements` — the backing methods behind
+  the `table_configuration` / `column_requirements` `auth_cached_method`
+  declarations — were defined publicly. Rodauth registers those via
+  `auth_private_methods` and, as of 2.45.0, audits each backing method with
+  `private_method_defined?` at feature-definition time, so loading the feature
+  printed two `"Bug in Rodauth table_guard feature definition..."` warnings on
+  stderr. Both methods moved into the feature's `private` section (matching
+  `account_id_obfuscation` and `external_identity`). Upstream marks the warning
+  `RODAUTH3: raise instead of warn`, so this would have become a load-time error.
+  Added `spec/rodauth/feature_configuration_spec.rb`, which mirrors rodauth's
+  audit across all five features so a regression fails the suite.
+
 ## [0.4.0] - 2026-07-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ end
 
 **Existence Checks (no logger suppression):** The `table_exists?` method matches names against the database's table/view list (`db.tables` + `db.views`) rather than probing each table with a SELECT. An earlier implementation used Sequel's `table_exists?` probe and suppressed the logger around it (clearing/restoring the shared `db.loggers` array) to hide the "no such table" ERROR that Sequel logs before catching internally — but that mutation of shared connection state was not thread-safe. Listing names avoids the failed probe entirely, so no logger suppression (and no shared-state mutation) is needed. Schema-qualified identifiers (a `Sequel::SQL::QualifiedIdentifier` or a `:schema__table` Symbol) are not present in the unqualified list, so they take a separate schema-aware `db.table_exists?` probe path.
 
+**Cached-Method Backing Visibility:** `auth_cached_method :foo` registers `foo` via `auth_private_methods`, so the backing `_foo` must be defined **private**. Rodauth 2.45.0 audits this at feature-definition time with `private_method_defined?` and warns (`RODAUTH3: raise instead of warn`) when it isn't — a publicly-defined `_foo` trips the audit even though it exists. `_table_configuration` and `_column_requirements` therefore live below the feature's `private` keyword, alongside the equivalent backing methods in `account_id_obfuscation` and `external_identity`. `spec/rodauth/feature_configuration_spec.rb` mirrors that audit across every feature this gem defines.
+
 **Configuration Storage:** Uses instance variables set by `auth_value_method`:
 
 - Block configs stored as Procs in `@table_guard_mode`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rodauth-tools (0.4.0)
+    rodauth-tools (0.4.1)
       dry-inflector (~> 1.1)
       rodauth (~> 2.41)
       sequel (~> 5.0)

--- a/docs/unresolved-bugs.md
+++ b/docs/unresolved-bugs.md
@@ -544,7 +544,7 @@ Nth drop) leaves the schema untouched (PostgreSQL/SQLite).
 
 **Problem.** Both modes enumerate
 `table_configuration.map { |_, info| info[:name] }` — the discovered `*_table`
-methods. By the project's own "Hidden Tables" design (see `CLAUDE.md`),
+methods. By the project's own "Hidden Tables" design (see `AGENTS.md`),
 `account_statuses` and `account_password_hashes` have **no** `*_table` method,
 so they are absent from that list. `:recreate` therefore drops `accounts` but
 leaves the two hidden tables in place, then `execute_creates` re-runs
@@ -1152,7 +1152,7 @@ strategy:
 (Bare minor versions let `ruby/setup-ruby` track patch releases.) If the
 maintainer would rather not support older rubies for an experimental project,
 raise the gemspec floor to `>= 3.4` instead — the bug is the *mismatch*, and
-either edit closes it. Given `CLAUDE.md` calls this a reference
+either edit closes it. Given `AGENTS.md` calls this a reference
 implementation, testing the documented floor is the better look.
 
 ---

--- a/lib/rodauth/features/table_guard.rb
+++ b/lib/rodauth/features/table_guard.rb
@@ -136,30 +136,6 @@ module Rodauth
       mode_value != :silent && mode_value != :skip && !mode_value.nil?
     end
 
-    # Internal method called by auth_cached_method :table_configuration
-    #
-    # Discovers and returns table configuration. This is called lazily
-    # per-instance and the result is cached in @table_configuration.
-    #
-    # @return [Hash<Symbol, Hash>] Table configuration
-    def _table_configuration
-      config = Rodauth::TableInspector.table_information(self)
-      rodauth_debug("[table_guard] Discovered #{config.size} required tables") if ENV['RODAUTH_DEBUG']
-      config
-    end
-
-    # Internal method called by auth_cached_method :column_requirements
-    #
-    # Initializes and returns column requirements hash. This is called lazily
-    # per-instance and the result is cached in @column_requirements.
-    #
-    # Structure: { table_name => { column_name => { type:, null:, feature: } } }
-    #
-    # @return [Hash<Symbol, Hash<Symbol, Hash>>] Column requirements by table
-    def _column_requirements
-      {}
-    end
-
     # Check required tables and handle based on mode
     #
     # This is the main entry point for table validation
@@ -449,6 +425,33 @@ module Rodauth
     end
 
     private
+
+    # Backing method for the +table_configuration+ auth_cached_method.
+    #
+    # Discovers and returns table configuration. This is called lazily
+    # per-instance and the result is cached in @table_configuration.
+    #
+    # Must stay private: rodauth registers it via auth_private_methods and (as
+    # of rodauth 2.45.0) warns when the backing method is not defined privately.
+    #
+    # @return [Hash<Symbol, Hash>] Table configuration
+    def _table_configuration
+      config = Rodauth::TableInspector.table_information(self)
+      rodauth_debug("[table_guard] Discovered #{config.size} required tables") if ENV['RODAUTH_DEBUG']
+      config
+    end
+
+    # Backing method for the +column_requirements+ auth_cached_method.
+    #
+    # Initializes and returns column requirements hash. This is called lazily
+    # per-instance and the result is cached in @column_requirements.
+    #
+    # Structure: { table_name => { column_name => { type:, null:, feature: } } }
+    #
+    # @return [Hash<Symbol, Hash<Symbol, Hash>>] Column requirements by table
+    def _column_requirements
+      {}
+    end
 
     # Build the set of unqualified table names that currently exist, including
     # views (which db.tables omits on most adapters but which can legitimately

--- a/lib/rodauth/tools/version.rb
+++ b/lib/rodauth/tools/version.rb
@@ -4,6 +4,6 @@
 
 module Rodauth
   module Tools
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/spec/rodauth/feature_configuration_spec.rb
+++ b/spec/rodauth/feature_configuration_spec.rb
@@ -1,0 +1,62 @@
+# spec/rodauth/feature_configuration_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# hmac_secret_guard/jwt_secret_guard are not auto-required by rodauth/tools.
+require 'rodauth/features/hmac_secret_guard'
+require 'rodauth/features/jwt_secret_guard'
+
+# Every feature this gem defines, checked against rodauth's own audit below.
+tools_features = %i[
+  table_guard
+  external_identity
+  account_id_obfuscation
+  hmac_secret_guard
+  jwt_secret_guard
+].freeze
+
+# Rodauth 2.45.0 added a definition-time audit of every feature's configuration
+# methods (Rodauth::FeatureConfiguration#_check_method_defined): a configuration
+# method registered for a method the feature never defines means the
+# configuration method silently does nothing. Today that emits
+#
+#   "Bug in Rodauth <feature> feature definition, configuration method added for
+#    <meth>, but the feature doesn't define the method"
+#
+# on stderr at require time; upstream marks it "RODAUTH3: raise instead of warn",
+# so a miss here becomes a load-time error in the next major release.
+#
+# These examples mirror that audit for the features this gem defines, so the
+# breakage is caught here rather than as boot noise (eventually a boot failure)
+# in a downstream app.
+RSpec.describe Rodauth::FeatureConfiguration do
+  tools_features.each do |feature_name|
+    describe "#{feature_name} feature" do
+      let(:feature) { Rodauth::FEATURES.fetch(feature_name) }
+
+      it 'defines every method it registers a configuration method for' do
+        registered = feature.auth_methods + feature.auth_value_methods
+        undefined = registered.reject { |meth| feature.method_defined?(meth) || feature.private_method_defined?(meth) }
+
+        expect(undefined).to be_empty,
+                             "#{feature_name} registers configuration methods for #{undefined.join(", ")} " \
+                             'but does not define them'
+      end
+
+      # auth_private_methods :foo (and auth_cached_method :foo, which calls it)
+      # register a configuration method that redefines `_foo` PRIVATELY, so
+      # rodauth checks the backing method with private_method_defined?. A
+      # publicly-defined `_foo` fails that check even though it exists.
+      it 'defines each auth_private_methods backing method privately' do
+        backing = feature.auth_private_methods.map { |meth| :"_#{meth}" }
+        not_private = backing.reject { |meth| feature.private_method_defined?(meth) }
+
+        expect(not_private).to be_empty,
+                               "#{feature_name} registers private configuration methods whose backing methods " \
+                               "#{not_private.join(", ")} are missing or not private"
+      end
+    end
+  end
+end

--- a/spec/rodauth/feature_configuration_spec.rb
+++ b/spec/rodauth/feature_configuration_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe Rodauth::FeatureConfiguration do
     describe "#{feature_name} feature" do
       let(:feature) { Rodauth::FEATURES.fetch(feature_name) }
 
+      # A feature may opt individual methods out of the audit by setting
+      # allowed_undefined_configuration_methods (2.45.0; nil unless the feature
+      # assigns it — rodauth's json feature is the only upstream user). The two
+      # mirrors below honour it so they cannot fail a feature that rodauth's own
+      # audit deliberately permits.
+      let(:allowed_undefined) { feature.allowed_undefined_configuration_methods || [] }
+
       # Runs rodauth's OWN audit rather than a copy of it, so this example
       # cannot drift as upstream tightens the check, and it honours
       # allowed_undefined_configuration_methods (2.45.0's opt-out, used by
@@ -69,7 +76,9 @@ RSpec.describe Rodauth::FeatureConfiguration do
 
       it 'defines every method it registers a configuration method for' do
         registered = feature.auth_methods + feature.auth_value_methods
-        undefined = registered.reject { |meth| feature.method_defined?(meth) || feature.private_method_defined?(meth) }
+        undefined = registered.reject do |meth|
+          feature.method_defined?(meth) || feature.private_method_defined?(meth) || allowed_undefined.include?(meth)
+        end
 
         expect(undefined).to be_empty,
                              "#{feature_name} registers configuration methods for #{undefined.join(", ")} " \
@@ -80,9 +89,13 @@ RSpec.describe Rodauth::FeatureConfiguration do
       # register a configuration method that redefines `_foo` PRIVATELY, so
       # rodauth checks the backing method with private_method_defined?. A
       # publicly-defined `_foo` fails that check even though it exists.
+      #
+      # Upstream passes the ALREADY-prefixed name to its opt-out check, so an
+      # opt-out here has to be spelled `:_foo`, not `:foo`. Accepting both would
+      # make this mirror laxer than the audit it mirrors.
       it 'defines each auth_private_methods backing method privately' do
         backing = feature.auth_private_methods.map { |meth| :"_#{meth}" }
-        not_private = backing.reject { |meth| feature.private_method_defined?(meth) }
+        not_private = backing.reject { |meth| feature.private_method_defined?(meth) || allowed_undefined.include?(meth) }
 
         expect(not_private).to be_empty,
                                "#{feature_name} registers private configuration methods whose backing methods " \

--- a/spec/rodauth/feature_configuration_spec.rb
+++ b/spec/rodauth/feature_configuration_spec.rb
@@ -34,9 +34,9 @@ raise "no feature files found under #{features_dir}" if tools_features.empty?
 # on stderr at require time; upstream marks it "RODAUTH3: raise instead of warn",
 # so a miss here becomes a load-time error in the next major release.
 #
-# These examples mirror that audit for the features this gem defines, so the
-# breakage is caught here rather than as boot noise (eventually a boot failure)
-# in a downstream app.
+# For each feature this gem defines, the examples below both re-run that audit
+# and mirror what it checks, so the breakage is caught here rather than as boot
+# noise (eventually a boot failure) in a downstream app.
 RSpec.describe Rodauth::FeatureConfiguration do
   def capture_warnings
     old_stderr = $stderr

--- a/spec/rodauth/feature_configuration_spec.rb
+++ b/spec/rodauth/feature_configuration_spec.rb
@@ -3,19 +3,25 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'stringio'
 
-# hmac_secret_guard/jwt_secret_guard are not auto-required by rodauth/tools.
-require 'rodauth/features/hmac_secret_guard'
-require 'rodauth/features/jwt_secret_guard'
+# Every feature this gem defines, derived from the filesystem rather than a
+# hand-maintained list so a newly added feature is covered the moment its file
+# lands. Each file defines exactly one feature whose name matches its basename.
+#
+# Requiring them here is also what makes the audit below run at all: rodauth
+# audits a feature inside Feature.define, so a feature file nothing requires is
+# never checked. rodauth/tools does not auto-require hmac_secret_guard or
+# jwt_secret_guard, so the spec_helper require alone would miss them.
+features_dir = File.expand_path('../../lib/rodauth/features', __dir__)
+tools_features = Dir["#{features_dir}/*.rb"].map do |path|
+  require path
+  File.basename(path, '.rb').to_sym
+end
 
-# Every feature this gem defines, checked against rodauth's own audit below.
-tools_features = %i[
-  table_guard
-  external_identity
-  account_id_obfuscation
-  hmac_secret_guard
-  jwt_secret_guard
-].freeze
+# Guards the derivation itself: a glob that silently stopped matching would
+# otherwise reduce this whole file to zero examples and still go green.
+raise "no feature files found under #{features_dir}" if tools_features.empty?
 
 # Rodauth 2.45.0 added a definition-time audit of every feature's configuration
 # methods (Rodauth::FeatureConfiguration#_check_method_defined): a configuration
@@ -32,9 +38,34 @@ tools_features = %i[
 # breakage is caught here rather than as boot noise (eventually a boot failure)
 # in a downstream app.
 RSpec.describe Rodauth::FeatureConfiguration do
+  def capture_warnings
+    old_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = old_stderr
+  end
+
   tools_features.each do |feature_name|
     describe "#{feature_name} feature" do
       let(:feature) { Rodauth::FEATURES.fetch(feature_name) }
+
+      # Runs rodauth's OWN audit rather than a copy of it, so this example
+      # cannot drift as upstream tightens the check, and it honours
+      # allowed_undefined_configuration_methods (2.45.0's opt-out, used by
+      # rodauth's json feature for only_json?) for free. Re-running
+      # def_configuration_methods is idempotent: it redefines the same
+      # configuration methods on the same FeatureConfiguration module.
+      #
+      # The two examples below duplicate the checks it performs; they are kept
+      # because upstream only emits a warning string, while they name the
+      # offending methods and say which rule was broken.
+      it "passes rodauth's own feature-definition audit" do
+        warnings = capture_warnings { feature.configuration.def_configuration_methods(feature) }
+
+        expect(warnings).to be_empty
+      end
 
       it 'defines every method it registers a configuration method for' do
         registered = feature.auth_methods + feature.auth_value_methods


### PR DESCRIPTION
## Summary

Rodauth 2.45.0 added a definition-time audit of every feature&#39;s configuration methods (`Rodauth::FeatureConfiguration#_check_method_defined`). For each `auth_private_methods` entry it checks the backing `_method` with `private_method_defined?`, and warns when the feature doesn&#39;t define it that way.

`auth_cached_method :table_configuration` / `:column_requirements` route through `auth_private_methods`, but `_table_configuration` and `_column_requirements` were defined *above* the feature&#39;s `private` keyword. So on 2.45.0, merely requiring `table_guard` prints:

```
Bug in Rodauth table_guard feature definition, configuration method added for _table_configuration, but the feature doesn't define the method
Bug in Rodauth table_guard feature definition, configuration method added for _column_requirements, but the feature doesn't define the method
```

Upstream marks that `# RODAUTH3: raise instead of warn`, so this is a load-time error waiting for the next major.

Both methods move into the feature&#39;s `private` section, matching the equivalent backing methods in `account_id_obfuscation` (`_account_id_ciphers`) and `external_identity` (`_external_identity_columns_config`), which already sat there and never tripped the audit. Behavior is unchanged — every caller reaches them through the public `table_configuration` / `column_requirements` accessors that `auth_cached_method` generates.

Released as **0.4.1** (patch: bug fix, no API change).

## Audit coverage

`spec/rodauth/feature_configuration_spec.rb` turns the audit into a permanent guard, in two layers:

1. **Runs rodauth&#39;s own audit.** Each feature re-invokes `feature.configuration.def_configuration_methods(feature)` with stderr captured and asserts silence. That can&#39;t drift as upstream tightens the check, and it honours `allowed_undefined_configuration_methods` — the opt-out 2.45.0 added alongside the audit (rodauth&#39;s own `json` feature uses it for `only_json?`) — for free. Re-running is idempotent: it redefines the same configuration methods on the same `FeatureConfiguration` module.
2. **Mirrors what it checks**, so a failure names the offending methods and the rule broken rather than just reproducing a warning string: every `auth_methods` / `auth_value_methods` entry is defined, and every `auth_private_methods` backing method exists *and* is private.

The feature list is derived from `lib/rodauth/features/*.rb` rather than hand-maintained, so a sixth feature is covered the moment its file lands — a hardcoded list would have grown a silent hole, which is the failure mode the audit exists to prevent. Requiring those files is also what makes the audit run at all: rodauth audits inside `Feature.define`, so a feature file nothing requires is never checked. That replaces the manual requires of the two secret guards, which `rodauth/tools` does not auto-require.

Verified in both directions:

- restoring the pre-fix `table_guard` fails both the upstream-audit example and the mirrored one (`table_guard registers private configuration methods whose backing methods _table_configuration, _column_requirements are missing or not private`);
- dropping in a new feature file whose `auth_cached_method` backing is public is picked up automatically (15 → 18 examples) and fails, with no edit to the spec.

## Test Plan

- `bundle exec rspec spec` — 328 examples, 0 failures (was 313 on main; +15 from the new spec file)
- `bundle exec rubocop lib/ spec/` — 32 files, no offenses
- `bundle install` — lockfile updated to `rodauth-tools (0.4.1)`, no other movement
- Confirmed the two stderr warnings are gone when the features are required under rodauth 2.45.0

No dependency changes needed: `Gemfile.lock` was already on rodauth 2.45.0 and roda 3.106.0, and the gemspec floor (`rodauth ~&gt; 2.41`) still holds — the fix is correct on every 2.x.

## Ecosystem check

The audit only fires for code that *defines* Rodauth features, so I ran it across the rest of the stack:

- **rodauth-omniauth 0.6.2** — both features pass clean (`omniauth` 6 auth / 11 value / 7 private, `omniauth_base` 6 / 6 / 0). No change needed.
- **onetimesecret** — defines no features of its own; it configures existing ones via `auth_class_eval`, which the audit doesn&#39;t reach.

## Downstream

onetimesecret/onetimesecret consumes rodauth-tools 0.4.0, so it keeps printing the two warnings until 0.4.1 is published — they&#39;re stderr-only and non-fatal. Noted in onetimesecret/onetimesecret#4109, which is the PR that moves that app to rodauth 2.45.0; that app&#39;s dependency can be bumped once this is released.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjS25g5mca3H1Um7s7eW8f)_