### PR TITLE
Track audit report; add 2026-07-09 audit

### DIFF
--- a/docs/security/.gitignore
+++ b/docs/security/.gitignore
@@ -1,0 +1,4 @@
+# docs/.gitignore excludes dated markdown notes (`[1-9]*-*.md`) as a general
+# rule for scratch/session docs. Security audit reports use that same
+# YYYY-MM-DD.md naming but are meant to be tracked, so un-ignore them here.
+!*.md

--- a/docs/security/2026-07-09.md
+++ b/docs/security/2026-07-09.md
@@ -1,0 +1,113 @@
+# Security & Bug Audit — 2026-07-09
+
+**Scope:** Full-repo scan for hardcoded secrets, weak crypto, injection risks,
+unsafe deserialization, insecure auth flows, and high-impact data/race bugs.
+**Baseline:** `main` @ `c044c0f` (2026-07-09). Compared against
+`docs/unresolved-bugs.md`, verified against `a600397` (2026-07-05), to avoid
+re-reporting known items.
+
+## Summary
+
+No new vulnerabilities found. This repo already has an exhaustive, current
+audit (`docs/unresolved-bugs.md`, 23 tracked items RT-01–RT-23) that remains
+accurate: only dependency-bump commits and one bug-fix commit landed since it
+was written.
+
+- **Fixed since the last audit:** RT-08 and RT-09 (`:recreate`/`:drop` table
+  enumeration and transactional atomicity), via commit `635fec7`. Verified
+  below — the fix is correct and introduces no regression.
+- **Still open, spot-checked against current `main`:** RT-01, RT-02, RT-03,
+  RT-04 (the highest-severity items) — all confirmed present at their
+  documented locations, unchanged.
+- **New code reviewed, no issues found:** `account_id_cipher.rb` (Feistel/HMAC
+  obfuscation primitive) and `account_id_obfuscation.rb`, which were only
+  tangentially covered by the prior audit (via RT-01's note that the
+  `production_env_check` pattern is copied there). No new findings beyond the
+  already-tracked RT-01 pattern, which applies to this feature too (see
+  below).
+- **No action needed:** commits since `a600397` are Dependabot version bumps
+  (`sequel`, `tilt`, `rubocop`) — out of scope per instructions (dependency
+  scanning is handled by Renovate/Dependabot).
+
+Do not re-open tickets for anything in `docs/unresolved-bugs.md` — file fixes
+against RT-01…RT-23 there, not as new findings here.
+
+## Verified: RT-08 / RT-09 fix is correct
+
+`lib/rodauth/features/table_guard.rb` (`:recreate`/`:drop`) and
+`lib/rodauth/sequel_generator.rb#execute_drops` now:
+
+- Enumerate tables to drop via `enabled_template_features` +
+  `TemplateInspector`, so hidden tables (`account_statuses`,
+  `account_password_hashes`) are included and dropped/recreated in
+  FK-dependency order.
+- Wrap the drop+create (or drop+tracking-drop) cycle in `db.transaction do
+  ... end`, so a mid-operation failure no longer leaves a partially dropped
+  schema on PostgreSQL/SQLite.
+
+No new issues introduced by this change.
+
+## Confirmed still-open (no new information, tracked in `docs/unresolved-bugs.md`)
+
+| ID | Sev | Title | Verified at |
+|---|---|---|---|
+| RT-01 | 🔴 | `production_env_check` exact-match fails open for any non-`"production"` value (`staging`, `prod`, unset `RACK_ENV` with only `RAILS_ENV` set) | `hmac_secret_guard.rb:74`, `jwt_secret_guard.rb:74` — same pattern also present in `account_id_obfuscation.rb:69` (not previously given its own RT number; see note below) |
+| RT-02 | 🟡 | `ENV.delete` makes each secret single-consumer across multiple Auth classes | `secret_guard.rb:44` |
+| RT-03 | 🟠 | Destructive `table_guard` modes gated by `RACK_ENV&.start_with?` prefix match, not exact match; `test-staging`/`devops-prod` pass | `table_guard.rb:679,696,742` |
+| RT-04 | 🟠 | `table_exists?` fails open (returns `true`) on any `StandardError`, so a broken DB connection is reported as "all tables exist" | `table_guard.rb:281-284` |
+
+**Note on RT-01's scope:** `account_id_obfuscation.rb:69` defines its own
+`production_env_check` with the identical
+`proc { ENV.fetch('RACK_ENV', 'production') == 'production' }` default. The
+prior audit's RT-01 solution section already names this file as needing the
+same shared-detector fix ("the same pattern"), so this is not a new finding —
+flagging here only to confirm the fix, when it lands, must touch three files
+(`hmac_secret_guard.rb`, `jwt_secret_guard.rb`, `account_id_obfuscation.rb`),
+not two.
+
+## Newly reviewed: `account_id_cipher.rb` / `account_id_obfuscation.rb`
+
+These files did not have their own RT items (only an indirect mention under
+RT-01). Reviewed in full this pass:
+
+- **Crypto design:** 4-round Feistel network keyed with HMAC-SHA256,
+  documented as pseudonymization (not confidentiality/access-control) with an
+  explicitly-stated birthday-bound caveat (~2^16 tokens/secret). This is an
+  appropriate and honestly-documented threat model for its stated purpose
+  (hiding sequential integer IDs from casual observation in email links/
+  cookies) — not flagging as a finding.
+- **Secret handling:** shares `Rodauth::SecretGuard` plumbing with the other
+  two guards (ENV load-and-delete, blank detection, min-length enforcement);
+  same RT-01/RT-02 patterns apply and are already tracked, not duplicated
+  here.
+- **Key-version validation** (`validate_key_version!`) correctly rejects
+  digit version tags and duplicate versions across current/previous secrets —
+  no bypass found.
+- **`decode`'s canonical round-trip check** (`encode(id) == token`) uses
+  non-constant-time `String#==`. Considered and not flagged: the compared
+  value is a ciphertext round-trip check, not a secret being brute-forced
+  byte-by-byte, and the token an attacker could observe is already public
+  (it's in the URL/cookie they control), so there is no exploitable secret
+  boundary here.
+
+No findings.
+
+## Areas checked with no issues
+
+- No hardcoded production secrets, API keys, or credentials found in `lib/`,
+  `examples/`, or CI workflows (grepped for common patterns).
+- No raw SQL string interpolation in Sequel query paths — table/column
+  identifiers go through Sequel's DSL for actual execution (the codegen-time
+  string interpolation issues are already tracked as RT-13/RT-14/RT-16).
+- No `Marshal.load`, `YAML.load` (unsafe form), `eval` of external input, or
+  `send`/`public_send` on attacker-controlled method names.
+- CI workflows unchanged since the last audit; RT-18–RT-22 findings stand as
+  documented, no new workflow files added.
+
+## Recommendation
+
+No action required from this pass. The highest-value next step remains what
+`docs/unresolved-bugs.md`'s "Suggested fix sequencing" already recommends:
+RT-03/RT-04 next (both 🟠, both fail-open on the exact class of fault the
+feature exists to catch), then the RT-01/RT-02 shared-detector work — which,
+per the note above, should also update `account_id_obfuscation.rb`.


### PR DESCRIPTION
docs/.gitignore excludes dated markdown notes as scratch/session docs, but security audit reports should stay in version history. Add a docs/security/.gitignore override to un-ignore .md files there, and commit this pass's audit (no new findings; confirms RT-08/RT-09 fixed, RT-01-04 still open per docs/unresolved-bugs.md).
